### PR TITLE
[fd] Use --no-ignore-vcs as a default instead of --no-ignore (-I)

### DIFF
--- a/fnl/snap/producer/fd/directory.fnl
+++ b/fnl/snap/producer/fd/directory.fnl
@@ -2,5 +2,5 @@
       general (snap.get :producer.fd.general)]
   (fn [request]
     (let [cwd (snap.sync vim.fn.getcwd)]
-      (general request {:args [:-H :-I :-t :d] : cwd}))))
+      (general request {:args [:-H :--no-ignore-vcs :-t :d] : cwd}))))
 

--- a/fnl/snap/producer/fd/file.fnl
+++ b/fnl/snap/producer/fd/file.fnl
@@ -2,4 +2,4 @@
       general (snap.get :producer.fd.general)]
   (fn [request]
     (let [cwd (snap.sync vim.fn.getcwd)]
-      (general request {:args [:-H :-I] : cwd}))))
+      (general request {:args [:-H :--no-ignore-vcs] : cwd}))))

--- a/lua/snap/producer/fd/directory.lua
+++ b/lua/snap/producer/fd/directory.lua
@@ -3,6 +3,6 @@ local snap = require("snap")
 local general = snap.get("producer.fd.general")
 local function _1_(request)
   local cwd = snap.sync(vim.fn.getcwd)
-  return general(request, {args = {"-H", "-I", "-t", "d"}, cwd = cwd})
+  return general(request, {args = {"-H", "--no-ignore-vcs", "-t", "d"}, cwd = cwd})
 end
 return _1_

--- a/lua/snap/producer/fd/file.lua
+++ b/lua/snap/producer/fd/file.lua
@@ -3,6 +3,6 @@ local snap = require("snap")
 local general = snap.get("producer.fd.general")
 local function _1_(request)
   local cwd = snap.sync(vim.fn.getcwd)
-  return general(request, {args = {"-H", "-I"}, cwd = cwd})
+  return general(request, {args = {"-H", "--no-ignore-vcs"}, cwd = cwd})
 end
 return _1_


### PR DESCRIPTION
`-I` is a little bit heavy handed as a default, it will even ignore `.ignore` & `.fdignore` files.

`--no-ignore-vcs` will only ignore `.gitignore` but respect `.ignore` or `.fdignore`

From `fd --help`

```
-I, --no-ignore
        Show search results from files and directories that would otherwise be ignored by '.gitignore',
        '.ignore', '.fdignore', or the global ignore file.
    --no-ignore-vcs
        Show search results from files and directories that would otherwise be ignored by '.gitignore'
        Alias for '--no-ignore'. Can be repeated. '-uu' is an alias for '--no-ignore --hidden'.
```

Which will also work with https://github.com/camspiers/snap/issues/3#issuecomment-858142399