### PR TITLE
Extending the file/directory producers for fd to be more configurable

### DIFF
--- a/fnl/snap/producer/fd/directory.fnl
+++ b/fnl/snap/producer/fd/directory.fnl
@@ -1,6 +1,16 @@
 (let [snap (require :snap)
+      tbl (snap.get :common.tbl)
       general (snap.get :producer.fd.general)]
-  (fn [request]
+  (local directory {})
+  (local args [:--no-ignore-vcs :-t :d])
+  (fn directory.default [request]
     (let [cwd (snap.sync vim.fn.getcwd)]
-      (general request {:args [:-H :--no-ignore-vcs :-t :d] : cwd}))))
-
+      (general request {: args : cwd})))
+  (fn directory.hidden [request]
+    (let [cwd (snap.sync vim.fn.getcwd)]
+      (general request {:args [:--hidden (unpack args)] : cwd})))
+  (fn directory.args [new-args]
+    (fn [request]
+      (let [cwd (snap.sync vim.fn.getcwd)]
+        (general request {:args (tbl.concat args new-args) : cwd}))))
+  directory)

--- a/fnl/snap/producer/fd/file.fnl
+++ b/fnl/snap/producer/fd/file.fnl
@@ -1,5 +1,16 @@
 (let [snap (require :snap)
+      tbl (snap.get :common.tbl)
       general (snap.get :producer.fd.general)]
-  (fn [request]
+  (local file {})
+  (local args [:--no-ignore-vcs])
+  (fn file.default [request]
     (let [cwd (snap.sync vim.fn.getcwd)]
-      (general request {:args [:-H :--no-ignore-vcs] : cwd}))))
+      (general request {: args : cwd})))
+  (fn file.hidden [request]
+    (let [cwd (snap.sync vim.fn.getcwd)]
+      (general request {:args [:--hidden (unpack args)] : cwd})))
+  (fn file.args [new-args]
+    (fn [request]
+      (let [cwd (snap.sync vim.fn.getcwd)]
+        (general request {:args (tbl.concat args new-args) : cwd}))))
+  file)

--- a/lua/snap/producer/fd/directory.lua
+++ b/lua/snap/producer/fd/directory.lua
@@ -1,8 +1,22 @@
 local _2afile_2a = "fnl/snap/producer/fd/directory.fnl"
 local snap = require("snap")
+local tbl = snap.get("common.tbl")
 local general = snap.get("producer.fd.general")
-local function _1_(request)
+local directory = {}
+local args = {"--no-ignore-vcs", "-t", "d"}
+directory.default = function(request)
   local cwd = snap.sync(vim.fn.getcwd)
-  return general(request, {args = {"-H", "--no-ignore-vcs", "-t", "d"}, cwd = cwd})
+  return general(request, {args = args, cwd = cwd})
 end
-return _1_
+directory.hidden = function(request)
+  local cwd = snap.sync(vim.fn.getcwd)
+  return general(request, {args = {"--hidden", unpack(args)}, cwd = cwd})
+end
+directory.args = function(new_args)
+  local function _1_(request)
+    local cwd = snap.sync(vim.fn.getcwd)
+    return general(request, {args = tbl.concat(args, new_args), cwd = cwd})
+  end
+  return _1_
+end
+return directory

--- a/lua/snap/producer/fd/file.lua
+++ b/lua/snap/producer/fd/file.lua
@@ -1,8 +1,22 @@
 local _2afile_2a = "fnl/snap/producer/fd/file.fnl"
 local snap = require("snap")
+local tbl = snap.get("common.tbl")
 local general = snap.get("producer.fd.general")
-local function _1_(request)
+local file = {}
+local args = {"--no-ignore-vcs"}
+file.default = function(request)
   local cwd = snap.sync(vim.fn.getcwd)
-  return general(request, {args = {"-H", "--no-ignore-vcs"}, cwd = cwd})
+  return general(request, {args = args, cwd = cwd})
 end
-return _1_
+file.hidden = function(request)
+  local cwd = snap.sync(vim.fn.getcwd)
+  return general(request, {args = {"--hidden", unpack(args)}, cwd = cwd})
+end
+file.args = function(new_args)
+  local function _1_(request)
+    local cwd = snap.sync(vim.fn.getcwd)
+    return general(request, {args = tbl.concat(args, new_args), cwd = cwd})
+  end
+  return _1_
+end
+return file


### PR DESCRIPTION
I know I said I will look at it on the weekend, but I had some time :)

I tried to follow the same exact structure you had for `ripgrep` & also I changed `fd.directory` _not very sure about that_

I am also not sure why there is `.hidden{}` seems like default & `.args{}` can cover `.hidden{}` already.

https://github.com/camspiers/snap/pull/11#issuecomment-859098599