### PR TITLE
Trivial change to enable users to customize the prompt ">" character as well

### DIFF
--- a/fnl/snap/init.fnl
+++ b/fnl/snap/init.fnl
@@ -194,7 +194,7 @@
   (local original-winnr (vim.api.nvim_get_current_win))
 
   ;; Configures a default or custom prompt
-  (local prompt (string.format "%s> " (or config.prompt :Find)))
+  (local prompt (string.format "%s " (or config.prompt :Find>)))
 
   ;; Stores the selected items, used for multiselect
   (var selected {})

--- a/lua/snap/init.lua
+++ b/lua/snap/init.lua
@@ -337,7 +337,7 @@ do
       local loading = (config.loading or get("loading"))
       local initial_filter = (config.initial_filter or "")
       local original_winnr = vim.api.nvim_get_current_win()
-      local prompt = string.format("%s> ", (config.prompt or "Find"))
+      local prompt = string.format("%s ", (config.prompt or "Find>"))
       local selected = {}
       local cursor_row = 1
       local function get_selection()


### PR DESCRIPTION
Not much to say here, is there anything I missed? I think this is better to have the full prompt customizable, so I can make it like so:

```lua
snap.run({
    prompt = 'Files ❱',
    producer = fzf(producer_file.args(ignore_dirs)),
    select = select_file.select,
    multiselect = select_file.multiselect,
    views = {preview_file}
})
```