### PR TITLE
Add missing type flag to fd.file

### DIFF
--- a/fnl/snap/producer/fd/file.fnl
+++ b/fnl/snap/producer/fd/file.fnl
@@ -2,7 +2,7 @@
       tbl (snap.get :common.tbl)
       general (snap.get :producer.fd.general)]
   (local file {})
-  (local args [:--no-ignore-vcs])
+  (local args [:--no-ignore-vcs :-t :f])
   (fn file.default [request]
     (let [cwd (snap.sync vim.fn.getcwd)]
       (general request {: args : cwd})))

--- a/lua/snap/producer/fd/file.lua
+++ b/lua/snap/producer/fd/file.lua
@@ -3,7 +3,7 @@ local snap = require("snap")
 local tbl = snap.get("common.tbl")
 local general = snap.get("producer.fd.general")
 local file = {}
-local args = {"--no-ignore-vcs"}
+local args = {"--no-ignore-vcs", "-t", "f"}
 file.default = function(request)
   local cwd = snap.sync(vim.fn.getcwd)
   return general(request, {args = args, cwd = cwd})


### PR DESCRIPTION
I think I might have missed adding that when I did #16. `fd` called without this will also return directories but that's handled by `fd.directory`