### PR TITLE
Defer treesiter load to reduce startup time

### DIFF
--- a/fnl/snap/preview/syntax.fnl
+++ b/fnl/snap/preview/syntax.fnl
@@ -1,7 +1,7 @@
-(let [has-treesitter (pcall require :nvim-treesitter)
-      (_ highlight) (pcall require :nvim-treesitter.highlight)
-      (_ parsers) (pcall require :nvim-treesitter.parsers)]
-  (fn [path bufnr]
+(fn [path bufnr]
+    (local has-treesitter (pcall require :nvim-treesitter))
+    (local (_ highlight) (pcall require :nvim-treesitter.highlight))
+    (local (_ parsers) (pcall require :nvim-treesitter.parsers))
     (local fake-path (.. (vim.fn.tempname) "/" path))
     (vim.api.nvim_buf_set_name bufnr fake-path)
     (vim.api.nvim_buf_call bufnr (fn []
@@ -21,4 +21,4 @@
             (parsers.has_parser lang)
             (highlight.attach bufnr lang)
             (vim.api.nvim_buf_set_option bufnr "syntax" filetype)))
-        (vim.api.nvim_buf_set_option bufnr "syntax" filetype)))))
+        (vim.api.nvim_buf_set_option bufnr "syntax" filetype))))

--- a/lua/snap/preview/syntax.lua
+++ b/lua/snap/preview/syntax.lua
@@ -1,8 +1,8 @@
 local _2afile_2a = "fnl/snap/preview/syntax.fnl"
-local has_treesitter = pcall(require, "nvim-treesitter")
-local _, highlight = pcall(require, "nvim-treesitter.highlight")
-local _0, parsers = pcall(require, "nvim-treesitter.parsers")
 local function _1_(path, bufnr)
+  local has_treesitter = pcall(require, "nvim-treesitter")
+  local _, highlight = pcall(require, "nvim-treesitter.highlight")
+  local _0, parsers = pcall(require, "nvim-treesitter.parsers")
   local fake_path = (vim.fn.tempname() .. "/" .. path)
   vim.api.nvim_buf_set_name(bufnr, fake_path)
   local function _2_()


### PR DESCRIPTION
This reduces the startup time of snap by around 3ms.