### PR TITLE
Fix typo in README usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ snap.run {
 
 ```lua
 snap.run {
-  producer = snap.get'consumer.fzy'(snap.get'producer.vim.oldfiles'),
+  producer = snap.get'consumer.fzy'(snap.get'producer.vim.oldfile'),
   select = snap.get'select.file'.select,
   multiselect = snap.get'select.file'.multiselect,
   views = {snap.get'preview.file'}


### PR DESCRIPTION
Fix a typo I came across in the Find Old Files example in README.