### PR TITLE
Add "insert" select function

### DIFF
--- a/README.md
+++ b/README.md
@@ -762,6 +762,10 @@ NOTE: Provides both `select` and `multiselect`.
 
 Changes directory in response to selection. 
 
+#### `snap.select.insert`
+
+Inserts selection at cursor location.
+
 ```
 NOTE: Only provides `select`.
 ```

--- a/fnl/snap/select/insert.fnl
+++ b/fnl/snap/select/insert.fnl
@@ -1,0 +1,6 @@
+(module snap.select.insert)
+ t
+
+(defn select [selection winnr]
+
+  (vim.api.nvim_put [(tostring selection)] "c" true true))

--- a/lua/snap/select/insert.lua
+++ b/lua/snap/select/insert.lua
@@ -1,0 +1,58 @@
+local _2afile_2a = "fnl/snap/select/insert.fnl"
+local _0_
+do
+  local name_0_ = "snap.select.insert"
+  local module_0_
+  do
+    local x_0_ = package.loaded[name_0_]
+    if ("table" == type(x_0_)) then
+      module_0_ = x_0_
+    else
+      module_0_ = {}
+    end
+  end
+  module_0_["aniseed/module"] = name_0_
+  module_0_["aniseed/locals"] = ((module_0_)["aniseed/locals"] or {})
+  do end (module_0_)["aniseed/local-fns"] = ((module_0_)["aniseed/local-fns"] or {})
+  do end (package.loaded)[name_0_] = module_0_
+  _0_ = module_0_
+end
+local autoload
+local function _1_(...)
+  return (require("aniseed.autoload")).autoload(...)
+end
+autoload = _1_
+local function _2_(...)
+  local ok_3f_0_, val_0_ = nil, nil
+  local function _2_()
+    return {}
+  end
+  ok_3f_0_, val_0_ = pcall(_2_)
+  if ok_3f_0_ then
+    _0_["aniseed/local-fns"] = {}
+    return val_0_
+  else
+    return print(val_0_)
+  end
+end
+local _local_0_ = _2_(...)
+local _2amodule_2a = _0_
+local _2amodule_name_2a = "snap.select.insert"
+do local _ = ({nil, _0_, nil, {{}, nil, nil, nil}})[2] end
+local select
+do
+  local v_0_
+  do
+    local v_0_0
+    local function select0(selection, winnr)
+      return vim.api.nvim_put({tostring(selection)}, "c", true, true)
+    end
+    v_0_0 = select0
+    _0_["select"] = v_0_0
+    v_0_ = v_0_0
+  end
+  local t_0_ = (_0_)["aniseed/locals"]
+  t_0_["select"] = v_0_
+  select = v_0_
+end
+return nil


### PR DESCRIPTION
This PR adds a 'insert selection into buffer' select provider.

I use snap to lookup target email addresses from a file
(via a lua function. Would push a PR, but my fennel is non-existant),
and this just inserts the result into the buffer.