### PR TITLE
Add snap.map/snap.maps with config API and command registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,9 @@ The full API:
 
   // An optional boolean or function that returning true displays the preview and when false hides
   preview?: boolean | function,
+
+  // An optional table of custom input buffer mappings, see mappings section below for options
+  mappings?: table
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ There are three primary APIs to be aware of in order to set up your local nvim t
 
 ### `snap.config`
 
-`snap.config` offers a easy API for creating functions that call `snap.run` with sensible configuration. It is merely and API that provides a terse API for generating functions that call `snap.run`.
+`snap.config` offers a terse API for creating functions that call `snap.run` with sensible configuration.
 
 ### `snap.run`
 
@@ -64,7 +64,7 @@ Though used directly infrequently, `snap.run` is the API to start a snap.
 
 ### Registering Global Keymaps
 
-The following illustrates some basic usage of the `snap.config` API, we generate a variety of functions and register them as normal mode mappings:
+The following illustrates some basic usage of the `snap.maps` and `snap.config` APIs, we generate a variety of functions and register them as normal mode mappings:
 
 ```lua
 local snap = require'snap'
@@ -76,7 +76,7 @@ snap.maps {
 }
 ```
 
-This gives a basic example, however see the [`snap.config`](#snap.config-api) section for all options available.
+This gives a basic example, however see the [`snap.config`](#config-api) section for all options available.
 
 ### Registering Global Keymaps With Defaults
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ use { 'camspiers/snap', rocks = {'fzy'}}
 Plug 'camspiers/snap'
 ```
 
-You will need to use `luarocks` manually if you want to install `fzy`, probably best to just use `fzf` if you are using vim-plug.
+With vim-plug you will need to use `luarocks` manually if you want to install `fzy`, probably best to just use `fzf` if you are using vim-plug.
 
 #### Semi-Optional Dependencies
 
@@ -48,82 +48,172 @@ They are semi-optional because you can mix and match them depending on which tec
 
 ## Getting Started
 
-By default `snap` doesn't configure any key mappings or commands for you, you will need to configure your own. Additionally `snap` uses a philosophy where global configuration is avoided, instead stateless configuration is provided to each invocation of `snap.run`.
+There are three primary APIs to be aware of in order to set up your local nvim to use `snap`.
 
-To generate a function that will invoke `snap.run` with a defined config you can use `snap.create`.
+### `snap.maps`
+
+`snap.maps` and `snap.map` will map a function to a particular keybinding. Any function can be registered (e.g your own lua functions), however usually you will register functions that result in a call to `snap.run`.
+
+### `snap.config`
+
+`snap.config` offers a easy API for creating functions that call `snap.run` with sensible configuration. It is merely and API that provides a terse API for generating functions that call `snap.run`.
+
+### `snap.run`
+
+Though used directly infrequently, `snap.run` is the API to start a snap.
 
 ### Registering Global Keymaps
 
+The following illustrates some basic usage of the `snap.config` API, we generate a variety of functions and register them as normal mode mappings:
+
 ```lua
 local snap = require'snap'
-
--- normal mode mapping <Leader><Leader> for searching files in cwd 
-snap.register.map('n', '<Leader><Leader>', snap.create(function ()
-  return {
-    producer = snap.get'consumer.fzy'(snap.get'producer.ripgrep.file'),
-    select = snap.get'select.file'.select,
-    multiselect = snap.get'select.file'.multiselect,
-    views = {snap.get'preview.file'}
-  }
-end))
-
--- creates normal mode mapping <Leader>f for grepping files in cwd 
-snap.register.map('n', '<Leader>f', snap.create(function ()
-  return {
-    producer = snap.get'producer.ripgrep.vimgrep',
-    select = snap.get'select.vimgrep'.select,
-    multiselect = snap.get'select.vimgrep'.multiselect,
-    views = {snap.get'preview.vimgrep'}
-  }
-end))
+snap.maps {
+  {"<Leader><Leader>", snap.config.file {producer = "ripgrep.file"}},
+  {"<Leader>fb", snap.config.file {producer = "vim.buffer"}},
+  {"<Leader>fo", snap.config.file {producer = "vim.oldfile"}},
+  {"<Leader>ff", snap.config.vimgrep {}},
+}
 ```
 
-### Registering Global Keymaps With Common Defaults
+This gives a basic example, however see the [`snap.config`](#snap.config-api) section for all options available.
 
-If you have some default configuration, e.g. `reverse = true` or a custom layout function you want to provide to all usages of `snap.run`, then you can take advantage of the `defaults` parameter of `snap.create`.
+### Registering Global Keymaps With Defaults
+
+Perhaps you want some default config to apply to all your `snap.config.file` usages, to do so you can generate your own version of `snap.config.file` or `snap.config.vimgrep` with applied defaults:
 
 ```lua
 local snap = require'snap'
+local file = snap.config.file:with {reverse = true, suffix = ">>", consumer = "fzy"}
+local vimgrep = snap.config.vimgrep:with {reverse = true, suffix = ">>", limit = 50000}
+snap.maps {
+  {"<Leader><Leader>", file {producer = "ripgrep.file"}},
+  {"<Leader>ff", vimgrep {}},
+}
+```
 
--- a custom create function that adds common defaults
-local function create(config)
-  return snap.create(config, {
-    -- use reverse results display for all configs
-    reverse = true,
-    -- use the bottom layout for all configs
-    layout = snap.get"layout".bottom,
-    mappings = {
-      enter = {"<CR>", "<C-o>"}, -- my custom mapping
-    }
-  })
-end
+### Registering Global Keymaps With Registered Commands
 
--- normal mode mapping <Leader><Leader> for searching files in cwd 
-snap.register.map('n', '<Leader><Leader>', create(function ()
-  return {
-    producer = snap.get'consumer.fzy'(snap.get'producer.ripgrep.file'),
-    select = snap.get'select.file'.select,
-    multiselect = snap.get'select.file'.multiselect,
-    views = {snap.get'preview.file'}
-  }
-end))
+If you want to also make your function available via the `:Snap myexamplefunction` API, you can pass an optional third parameter to `snap.map` or an optional third table value to each table to `snap.maps`.
 
--- creates normal mode mapping <Leader>f for grepping files in cwd 
-snap.register.map('n', '<Leader>f', create(function ()
-  return {
-    producer = snap.get'producer.ripgrep.vimgrep',
-    select = snap.get'select.vimgrep'.select,
-    multiselect = snap.get'select.vimgrep'.multiselect,
-    views = {snap.get'preview.vimgrep'}
-  }
-end))
+```lua
+local snap = require'snap'
+snap.maps {
+  {"<Leader><Leader>", snap.config.file {producer = "ripgrep.file"}, "mycommandname"}
+}
+```
+
+## Config API
+
+`snap.run` is designed to be a very general API used by composing different types of producers and consumers, instead of bundling defaults and configuration types into the general `snap.run` API, it is designed to be highly flexible and idempotent. So to ease the pain of creating your own functions that call `snap.run` with appropriate configuration, we instead provide `snap.config` for generating such functions with common configuration patterns.
+
+### `snap.config.file`
+
+The full API:
+
+```typescript
+{
+  // One of either producer, try or combine are required
+
+  // A required producer either by string identifier or a function
+  producer: "ripgrep.file"
+    | "fd.file"
+    | "vim.oldfile"
+    | "vim.buffer"
+    | "git.file"
+    | Producer,
+
+  // A table of producers, the first that returns results is used
+  try: table<
+    "ripgrep.file"
+    | "fd.file"
+    | "vim.oldfile"
+    | "vim.buffer"
+    | "git.file"
+    | Producer
+  >,
+
+  // A table of producers, combines returns from each
+  combine: table<
+    "ripgrep.file"
+    | "fd.file"
+    | "vim.oldfile"
+    | "vim.buffer"
+    | "git.file"
+    | Producer
+  >,
+
+  // Optionals
+
+  // An optional prompt string (without suffix e.g. ">")
+  prompt?: string,
+
+  // An optional suffix string e.g. ">>"
+  suffix?: string,
+
+  // An optional layout function, see layout API below
+  layout?: string,
+
+  // An optional table that passes args to producers that support it
+  args?: table<string>,
+
+  // An optional boolean that configures producers that suppport it
+  hidden?: boolean,
+
+  // An optional boolean that when true places the input at the top
+  reverse?: boolean,
+
+  // An optional number that chanes the minimun screen column width the preview should display at
+  preview-min-width?: number,
+
+  // An optional boolean or function that returning true displays the preview and when false hides
+  preview?: boolean | function,
+}
+```
+
+### Examples
+
+The following `snap.config.file` calls generate functions that run `snap.run` with various defaults.
+
+Each of these example functions generated would usually be passed to `snap.maps`, but you could also use them with any other mapping registration API, e.g. `which-key`.
+
+```lua
+-- Basic ripgrep file producer
+file {producer = "ripgrep.file"}
+
+-- Ripgrep file producer with args
+file {producer = "ripgrep.file", args = {'--hidden', '--iglob', '!.git/*'}}
+
+-- Git file producer with ripgrep fallback
+file {try = {"git.file", "ripgrep.file"}}
+
+-- Basic file producer with previews off
+file {producer = "ripgrep.file", preview = false}
+
+-- Basic buffer producer
+file {producer = "vim.buffer"}
+
+-- Basic oldfile producer
+file {producer = "vim.oldfile"}
+
+-- A customized prompt
+file {producer = "ripgrep.file", prompt = "MyFiles"}
+
+-- A customized prompt suffix
+file {producer = "ripgrep.file", suffix = ">>"}
+
+-- Display input at top
+file {producer = "ripgrep.file", reverse = true}
+
+-- Custom layout function
+file {producer = "ripgrep.file", layout = myCustomLayoutFunction}
 ```
 
 ## Recipes
 
 `snap` comes with inbuilt producers and consumers (see [How Snap Works](#how-snap-works) for what producers and consumers are) to enable easy creation of finders.
 
-The following recipes illustrate direct usage of `snap.run` meaning calling the following examples will immediately run snap, but as illustrated above when registering a mapping you most often want to get a function that will invoke `snap.run` with a particular config, in that case the following examples can be replaced with invocations to `snap.create` to get such a function.
+The following recipes illustrate direct usage of `snap.run` meaning calling the following examples will immediately run snap, but as illustrated above when registering a mapping you most often want to get a function that will invoke `snap.run` with a particular config, in that case the following examples can be replaced with invocations to `snap.config.file` to create the desired config.
 
 ### Find Files
 

--- a/fnl/snap/config/init.fnl
+++ b/fnl/snap/config/init.fnl
@@ -1,6 +1,6 @@
-(module snap.defaults {require {snap snap
-                                tbl snap.common.tbl}
-                       require-macros [snap.macros]})
+(module snap.config {require {snap snap
+                              tbl snap.common.tbl}
+                     require-macros [snap.macros]})
 
 (fn format-prompt [suffix prompt]
   "Formats a prompt"
@@ -12,7 +12,7 @@
   If for example you prefer fzy over fzf, then:
 
   -- This creates a version of snap.defaults.file with fzy set as the default consumer:
-  local file = defaults.file:with {consumer = 'fzy'}
+  local file = file:with {consumer = 'fzy'}
 
   -- Adds a mapping to search buffers
   snap.map('n', '<Leader>b', file {producer = 'vim.buffer'})"

--- a/fnl/snap/config/init.fnl
+++ b/fnl/snap/config/init.fnl
@@ -10,13 +10,14 @@
   (<= (vim.api.nvim_get_option :columns) (or min-width default-min-width)))
 
 (fn hide-views [config]
-  "Gives nice defaults for how previews should be display based on manual setting, custom function or display size
+  "Gives reasonable defaults for how previews should be display based on manual setting, custom function or display size
   
    if config.preview is nil or is true
-   then determinw if preview is disabled based on screen size
+     then determine if preview is disabled based on screen size
    if config.preview is set and is false
-   then always hide
-   if config.preview is a function call the function and return the negation of the result"
+     then always hide
+   if config.preview is a function
+     then call the function and return the negation of the result"
   (match (type config.preview)
     :nil (preview-disabled config.preview-min-width)
     :boolean (or (= config.preview false) (preview-disabled config.preview-min-width))
@@ -92,14 +93,17 @@
   - layout
   - prompt
   - suffix
+  - reverse
+  - preview-min-width
+  - preview
 
   Examples:
 
-  -- Runs with basic defaults, fzf and ripgrep.file
-  file {}
+  -- Runs ripgrep.file producer with fzf
+  file {producer = 'ripgrep.file'}
 
   -- Runs with fzy consumer
-  file {consumer = 'fzy'}
+  file {producer = 'ripgrep.file', consumer = 'fzy'}
 
   -- Runs with vim.oldfile producer
   file {producer = 'vim.oldfile'}
@@ -111,7 +115,7 @@
   file {producer = 'git.file'}
 
   -- Runs with git.file producer with ripgrep.file fallback
-  file {try = {'git.file', 'ripgrep.file}}
+  file {try = {'git.file', 'ripgrep.file'}}
 
   -- Customizes prompt
   file {prompt = 'My Prompt'}
@@ -190,11 +194,10 @@
   ;; Get the selection module
   (local select-file (snap.get :select.file))
 
-  (local hide-views (partial hide-views config))
-
   ;; Create a function to invoke snap
   (fn []
-    (let [reverse (or config.reverse false)
+    (let [hide-views (partial hide-views config)
+          reverse (or config.reverse false)
           layout  (or config.layout nil)
           producer (consumer producer)
           select select-file.select
@@ -297,10 +300,9 @@
 
   (local vimgrep-select (snap.get :select.vimgrep))
 
-  (local hide-views (partial hide-views config))
-
   (fn []
-    (let [reverse (or config.reverse false)
+    (let [hide-views (partial hide-views config)
+          reverse (or config.reverse false)
           layout (or config.layout nil)
           producer (consumer producer)
           select vimgrep-select.select

--- a/fnl/snap/config/init.fnl
+++ b/fnl/snap/config/init.fnl
@@ -142,6 +142,7 @@
   (asserttable?    config.combine           "file.combine must be a table")
   (assertboolean?  config.reverse           "file.reverse must be a boolean")
   (assertnumber?   config.preview-min-width "file.preview-min-with must be a boolean")
+  (asserttable?    config.mappings          "file.mappings must be a table")
   (asserttypes?    [:function :boolean] config.preview "file.preview must be a boolean or a function")
 
   ;; Ensure at least one producer config is set
@@ -199,11 +200,13 @@
     (let [hide-views (partial hide-views config)
           reverse (or config.reverse false)
           layout  (or config.layout nil)
+          mappings (or config.mappings nil)
           producer (consumer producer)
           select select-file.select
           multiselect select-file.multiselect
           views [(snap.get :preview.file)]]
       (snap.run {: prompt
+                 : mappings
                  : layout
                  : reverse
                  : producer
@@ -255,14 +258,15 @@
   vimgrep {layout = myCustomLayoutFunction}"
 
   (asserttable config)
-  (assertstring?   config.prompt  "vimgrep.prompt must be a string")
-  (assertnumber?   config.limit   "vimgrep.limit must be a number")
-  (assertfunction? config.layout  "vimgrep.layout must be a function")
-  (asserttable?    config.args    "vimgrep.args must be a table")
-  (assertboolean?  config.hidden  "vimgrep.hidden must be a boolean")
-  (assertstring?   config.suffix  "vimgrep.suffix must be a string")
-  (assertboolean?  config.reverse "vimgrep.reverse must be a boolean")
-  (assertboolean?  config.preview "vimgrep.preview must be a boolean")
+  (assertstring?   config.prompt   "vimgrep.prompt must be a string")
+  (assertnumber?   config.limit    "vimgrep.limit must be a number")
+  (assertfunction? config.layout   "vimgrep.layout must be a function")
+  (asserttable?    config.args     "vimgrep.args must be a table")
+  (assertboolean?  config.hidden   "vimgrep.hidden must be a boolean")
+  (assertstring?   config.suffix   "vimgrep.suffix must be a string")
+  (assertboolean?  config.reverse  "vimgrep.reverse must be a boolean")
+  (assertboolean?  config.preview  "vimgrep.preview must be a boolean")
+  (asserttable?    config.mappings "vimgrep.mappings must be a table")
 
   ;; Get the producer type
   (local producer-kind (or config.producer :ripgrep.vimgrep))
@@ -304,12 +308,14 @@
     (let [hide-views (partial hide-views config)
           reverse (or config.reverse false)
           layout (or config.layout nil)
+          mappings (or config.mappings nil)
           producer (consumer producer)
           select vimgrep-select.select
           multiselect vimgrep-select.multiselect
           views [(snap.get :preview.vimgrep)]]
       (snap.run {: prompt
                  : layout
+                 : mappings
                  : producer
                  : select
                  : multiselect

--- a/fnl/snap/defaults/init.fnl
+++ b/fnl/snap/defaults/init.fnl
@@ -1,0 +1,170 @@
+(module snap.defaults {require {snap snap
+                                tbl snap.common.tbl}
+                       require-macros [snap.macros]})
+
+(defn with [type defaults]
+  "Returns a new default with config pre-applied.
+
+  If for example you prefer fzy over fzf, that is you don't like the common default, then:
+
+  -- This creates a version of snap.defaults.file with fzy set as the default consumer:
+  local file = defaults.with(defaults.file, {consumer = 'fzy'})
+
+  -- Adds a mapping to search buffers
+  snap.map('n', '<Leader>b', file({producer = 'vim.buffer'}))
+"
+  (fn [config]
+    (type (tbl.merge defaults config))))
+
+(defn file [config]
+  "Returns a functon which runs `snap.run` for searching files with common file producers and common consumers.
+
+  Supported producers:
+
+  - ripgrep.file
+  - vim.oldfile
+  - vim.buffer
+  - vim.help
+  - git.file
+
+  Supported consumers:
+
+  - fzf
+  - fzy
+
+  Additional options:
+
+  - hidden
+  - args
+  - layout
+  - prompt
+
+  Examples:
+
+  -- Runs with basic defaults, fzf and ripgrep.file
+  defaults.file {}
+
+  -- Runs with fzy consumer
+  defaults.file {consumer = 'fzy'}
+
+  -- Runs with vim.oldfile producer
+  defaults.file {producer = 'vim.oldfile'}
+
+  -- Runs with vim.buffer producer
+  defaults.file {producer = 'vim.buffer'}
+
+  -- Runs with git.file producer
+  defaults.file {producer = 'git.file'}
+
+  -- Customizes prompt
+  defaults.file {prompt = 'My Prompt>'}
+
+  -- When using propducer = 'ripgrep.file' sets the hidden flag
+  defaults.file {hidden = true}
+
+  -- When using propducer = 'ripgrep.file' customizes the arguments
+  defaults.file {args = {'--hidden', '--iglob', '!.git/*'}}
+
+  -- Provides a custom layout function
+  defaults.file {layout = myCustomLayoutFunction}"
+
+  (asserttable config)
+  (assertstring? config.prompt "file.prompt must be a string")
+  (assertfunction? config.layout "file.layout must be a function")
+  (asserttable? config.args "file.args must be a table")
+  (assertboolean? config.hidden "file.hidden must be a boolean")
+
+  ;; Get the producer type
+  (local producer-type (or config.producer :ripgrep.file))
+  
+  ;; Consumer type
+  (local consumer-type (or config.consumer :fzf))
+
+  ;; Get the initial producer module based on type
+  (var producer (match producer-type
+    :ripgrep.file (snap.get :producer.ripgrep.file)
+    :vim.oldfile (snap.get :producer.vim.oldfile)
+    :vim.buffer (snap.get :producer.vim.buffer)
+    :git.file (snap.get :producer.git.file)
+    (where p (= (type p) :function)) p
+    _ (assert false "file.producer is invalid")))
+
+  ;; For ripgrep.file set custom args or hidden
+  (when
+    (= producer-type :ripgrep.file)
+    (if
+      config.args
+      (set producer (producer.args config.args))
+      config.hidden
+      (set producer producer.hidden)))
+
+  ;; Get the consumer module based on type
+  (local consumer (match consumer-type
+    :fzf (snap.get :consumer.fzf)
+    :fzy (snap.get :consumer.fzy)
+    (where c (= (type c) :function)) c
+    _ (assert false "file.consumer is invalid")))
+
+  ;; Create reasonable prompts based on types
+  (local prompt (or config.prompt (match producer-type
+    :ripgrep.file :Files>
+    :vim.oldfile "Old Files>"
+    :vim.buffer :Buffers>
+    :git.file "Git Files>"
+    _ "Files>")))
+
+  ;; Get the select module
+  (local select (snap.get :select.file))
+
+  ;; Create a function to invoke snap
+  (fn [] (snap.run {: prompt
+                        :reverse (or config.reverse false)
+                        :layout (or config.layout nil)
+                        :producer (consumer producer)
+                        :select select.select
+                        :multiselect select.multiselect
+                        :views [(snap.get :preview.file)]})))
+
+(defn vimgrep [config]
+  (asserttable config)
+  (assertstring? config.prompt "vimgrep.prompt must be a string")
+  (assertnumber? config.limit "vimgrep.limit must be a number")
+  (assertfunction? config.layout "vimgrep.layout must be a function")
+  (asserttable? config.args "vimgrep.args must be a table")
+  (assertboolean? config.hidden "vimgrep.hidden must be a boolean")
+
+  ;; Get the producer type
+  (local producer-type (or config.producer :ripgrep.vimgrep))
+
+  ;; Gets the producer based on the producer type
+  (var producer (match producer-type
+    :ripgrep.vimgrep (snap.get :producer.ripgrep.vimgrep)
+    (where p (= (type p) :function)) p
+    _ (assert false "vimgrep.producer is invalid")))
+
+  ;; Customize vimgrep
+  (when
+    (= producer-type :ripgrep.vimgrep)
+    (if
+      config.args
+      (set producer (producer.args config.args))
+      config.hidden
+      (set producer producer.hidden)))
+
+  ;; Gets a consumer based on options like limit
+  (local consumer
+    (if
+      config.limit
+      (partial (snap.get :consumer.limit) config.limit)
+      (fn [producer] producer)))
+
+  ;; Get the select module
+  (local select (snap.get :select.vimgrep))
+
+  (fn [] (snap.run {:prompt (or config.prompt :Grep>)
+                    :layout (or config.layout nil)
+                    :producer (consumer producer)
+                    :select select.select
+                    :multiselect select.multiselect
+                    :views [(snap.get :preview.vimgrep)]})))
+

--- a/fnl/snap/defaults/init.fnl
+++ b/fnl/snap/defaults/init.fnl
@@ -2,53 +2,51 @@
                                 tbl snap.common.tbl}
                        require-macros [snap.macros]})
 
-(fn create-prompt [suffix prompt]
+(fn format-prompt [suffix prompt]
+  "Formats a prompt"
   (string.format "%s%s" prompt (or suffix :>)))
 
 (fn with [fnc defaults]
   "Returns a new default with config pre-applied.
 
-  If for example you prefer fzy over fzf, that is you don't like the common default, then:
+  If for example you prefer fzy over fzf, then:
 
   -- This creates a version of snap.defaults.file with fzy set as the default consumer:
   local file = defaults.file:with {consumer = 'fzy'}
 
   -- Adds a mapping to search buffers
-  snap.map('n', '<Leader>b', file {producer = 'vim.buffer'})
-"
-  (fn [config]
-    (fnc (tbl.merge defaults config))))
+  snap.map('n', '<Leader>b', file {producer = 'vim.buffer'})"
+  (fn [config] (fnc (tbl.merge defaults config))))
 
 (fn file-producer-by-kind [config kind]
   "Gets a producer from producer type strings and handle special configs like args and hidden"
   (var producer (match kind
     :ripgrep.file (snap.get :producer.ripgrep.file)
-    :fd.file (snap.get :producer.fd.file)
-    :vim.oldfile (snap.get :producer.vim.oldfile)
-    :vim.buffer (snap.get :producer.vim.buffer)
-    :git.file (snap.get :producer.git.file)
+    :fd.file      (snap.get :producer.fd.file)
+    :vim.oldfile  (snap.get :producer.vim.oldfile)
+    :vim.buffer   (snap.get :producer.vim.buffer)
+    :git.file     (snap.get :producer.git.file)
     (where p (= (type p) :function)) p
     _ (assert false "file.producer is invalid")))
-
   ;; For ripgrep.file and fd.file set custom args or hidden
   (when
-    (or (= kind :ripgrep.file) (= kind :fd.file))
+    (or (= kind :ripgrep.file)
+        (= kind :fd.file))
     (if
       config.args
       (set producer (producer.args config.args))
       config.hidden
       (set producer producer.hidden)))
-
   producer)
 
-(fn file-prompt-by-kind [type]
-  (match type
+(fn file-prompt-by-kind [kind]
+  (match kind
     :ripgrep.file "Rg Files"
-    :fd.file "Fd Files"
-    :vim.oldfile "Old Files"
-    :vim.buffer "Buffers"
-    :git.file "Git Files"
-    _ "Custom Files"))
+    :fd.file      "Fd Files"
+    :vim.oldfile  "Old Files"
+    :vim.buffer   "Buffers"
+    :git.file     "Git Files"
+    _             "Custom Files"))
 
 (defmetafn file {: with} [config]
   "Returns a functon which runs `snap.run` for searching files with common file producers and common consumers.
@@ -78,51 +76,55 @@
   Examples:
 
   -- Runs with basic defaults, fzf and ripgrep.file
-  defaults.file {}
+  file {}
 
   -- Runs with fzy consumer
-  defaults.file {consumer = 'fzy'}
+  file {consumer = 'fzy'}
 
   -- Runs with vim.oldfile producer
-  defaults.file {producer = 'vim.oldfile'}
+  file {producer = 'vim.oldfile'}
 
   -- Runs with vim.buffer producer
-  defaults.file {producer = 'vim.buffer'}
+  file {producer = 'vim.buffer'}
 
   -- Runs with git.file producer
-  defaults.file {producer = 'git.file'}
+  file {producer = 'git.file'}
 
   -- Runs with git.file producer with ripgrep.file fallback
-  defaults.file {try = {'git.file', 'ripgrep.file}}
+  file {try = {'git.file', 'ripgrep.file}}
 
   -- Customizes prompt
-  defaults.file {prompt = 'My Prompt>'}
+  file {prompt = 'My Prompt'}
+
+  -- Customizes prompt suffix
+  file {suffix = '>>'}
 
   -- When using propducer = 'ripgrep.file' sets the hidden flag
-  defaults.file {hidden = true}
+  file {hidden = true}
 
   -- When using propducer = 'ripgrep.file' customizes the arguments
-  defaults.file {args = {'--hidden', '--iglob', '!.git/*'}}
+  file {args = {'--hidden', '--iglob', '!.git/*'}}
 
   -- Provides a custom layout function
-  defaults.file {layout = myCustomLayoutFunction}"
+  file {layout = myCustomLayoutFunction}"
 
-  (asserttable config)
-  (assertstring? config.prompt "file.prompt must be a string")
-  (assertfunction? config.layout "file.layout must be a function")
-  (asserttable? config.args "file.args must be a table")
-  (assertboolean? config.hidden "file.hidden must be a boolean")
-  (asserttable? config.try "file.try must be a table")
-  (asserttable? config.combine "file.combine must be a table")
+  (asserttable     config)
+  (assertstring?   config.prompt  "file.prompt must be a string")
+  (assertstring?   config.suffix  "file.suffix must be a string")
+  (assertfunction? config.layout  "file.layout must be a function")
+  (asserttable?    config.args    "file.args must be a table")
+  (assertboolean?  config.hidden  "file.hidden must be a boolean")
+  (asserttable?    config.try     "file.try must be a table")
+  (asserttable?    config.combine "file.combine must be a table")
 
   ;; Ensure at least one producer config is set
-  (assert (or config.producer config.try config.combine) "one of file.producer, file.try or file.combine must be set")A
+  (assert (or config.producer config.try config.combine) "one of file.producer, file.try or file.combine must be set")
 
   ;; Validate incompatible options
-  (assert (not (and config.producer config.try)) "file.try and file.producer can not be used together")
+  (assert (not (and config.producer config.try))     "file.try and file.producer can not be used together")
   (assert (not (and config.producer config.combine)) "file.combine and file.producer can not be used together")
-  (assert (not (and config.try config.combine)) "file.try and file.combine can not be used together")
-  (assert (not (and config.hidden config.args)) "file.args and file.hidden can not be used together")
+  (assert (not (and config.try      config.combine)) "file.try and file.combine can not be used together")
+  (assert (not (and config.hidden   config.args))    "file.args and file.hidden can not be used together")
 
   ;; Helper function with config applied
   (local by-kind (partial file-producer-by-kind config))
@@ -149,43 +151,80 @@
     _ (assert false "file.consumer is invalid")))
 
   ;; Defaults in the user defined suffix
-  (local create-prompt (partial create-prompt config.suffix))
+  (local add-prompt-suffix (partial format-prompt config.suffix))
 
   ;; Create reasonable prompts based on kinds
-  (local prompt (if
+  (local prompt (add-prompt-suffix (if
     config.prompt
-    (create-prompt config.prompt)
+    config.prompt
     config.producer
-    (create-prompt (file-prompt-by-kind config.producer))
+    (file-prompt-by-kind config.producer)
     config.try
-    (create-prompt (table.concat (vim.tbl_map file-prompt-by-kind config.try) " or "))
+    (table.concat (vim.tbl_map file-prompt-by-kind config.try) " or ")
     config.combine
-    (create-prompt (table.concat (vim.tbl_map file-prompt-by-kind config.combine) " + "))))
+    (table.concat (vim.tbl_map file-prompt-by-kind config.combine) " + "))))
 
-  ;; Get the select module
-  (local select (snap.get :select.file))
+  (local select-file (snap.get :select.file))
 
   ;; Create a function to invoke snap
-  (fn [] (snap.run {: prompt
-                    :reverse (or config.reverse false)
-                    :layout (or config.layout nil)
-                    :producer (consumer producer)
-                    :select select.select
-                    :multiselect select.multiselect
-                    :views [(snap.get :preview.file)]})))
+  (fn []
+    (let [reverse (or config.reverse false)
+          layout  (or config.layout nil)
+          producer (consumer producer)
+          select select-file.select
+          multiselect select-file.multiselect
+          views [(snap.get :preview.file)]]
+      (snap.run {: prompt : layout : reverse : producer : select : multiselect : views}))))
 
 (fn vimgrep-prompt-by-kind [kind]
   (match kind
     :ripgrep.vimgrep "Rg Vimgrep"
-    _ "Custom Vimgrep"))
+    _                "Custom Vimgrep"))
 
 (defmetafn vimgrep {: with} [config]
+  "Returns a functon which runs `snap.run` for grepping files.
+
+  Supported producers:
+
+  - ripgrep.vimgrep
+  - any producer function that returns results in the vimgrep format
+
+  Additional options:
+
+  - hidden
+  - args
+  - layout
+  - prompt
+  - suffix
+  - limit
+
+  Examples:
+
+  -- Runs with basic defaults, fzf and ripgrep.file
+  vimgrep {}
+
+  -- Customizes prompt
+  vimgrep {prompt = 'My Prompt'}
+
+  -- Customizes prompt suffix
+  vimgrep {suffix = '>>'}
+
+  -- When using propducer = 'ripgrep.vimgrep' sets the hidden flag
+  vimgrep {hidden = true}
+
+  -- When using propducer = 'ripgrep.vimgrep' customizes the arguments
+  vimgrep {args = {'--hidden', '--iglob', '!.git/*'}}
+
+  -- Provides a custom layout function
+  vimgrep {layout = myCustomLayoutFunction}"
+
   (asserttable config)
-  (assertstring? config.prompt "vimgrep.prompt must be a string")
-  (assertnumber? config.limit "vimgrep.limit must be a number")
+  (assertstring?   config.prompt "vimgrep.prompt must be a string")
+  (assertnumber?   config.limit  "vimgrep.limit must be a number")
   (assertfunction? config.layout "vimgrep.layout must be a function")
-  (asserttable? config.args "vimgrep.args must be a table")
-  (assertboolean? config.hidden "vimgrep.hidden must be a boolean")
+  (asserttable?    config.args   "vimgrep.args must be a table")
+  (assertboolean?  config.hidden "vimgrep.hidden must be a boolean")
+  (assertstring?   config.suffix "vimgrep.suffix must be a string")
 
   ;; Get the producer type
   (local producer-kind (or config.producer :ripgrep.vimgrep))
@@ -206,29 +245,28 @@
       (set producer producer.hidden)))
 
   ;; Gets a consumer based on options like limit
-  (local consumer
-    (if
-      config.limit
-      (partial (snap.get :consumer.limit) config.limit)
-      (fn [producer] producer)))
+  (local consumer (if
+    config.limit
+    (partial (snap.get :consumer.limit) config.limit)
+    (fn [producer] producer)))
 
   ;; Defaults in the user defined suffix
-  (local create-prompt (partial create-prompt config.suffix))
+  (local format-prompt (partial format-prompt config.suffix))
 
   ;; Get a reasonable default prompt based on kinds
-  (local prompt (if
+  (local prompt (format-prompt (if
     config.prompt
-    (create-prompt config.prompt)
+    config.prompt
     producer-kind
-    (create-prompt (vimgrep-prompt-by-kind producer-kind))))
+    (vimgrep-prompt-by-kind producer-kind))))
 
-  ;; Get the select module
-  (local select (snap.get :select.vimgrep))
+  (local vimgrep-select (snap.get :select.vimgrep))
 
-  (fn [] (snap.run {: prompt
-                    :layout (or config.layout nil)
-                    :producer (consumer producer)
-                    :select select.select
-                    :multiselect select.multiselect
-                    :views [(snap.get :preview.vimgrep)]})))
+  (fn []
+    (let [layout (or config.layout nil)
+          producer (consumer producer)
+          select vimgrep-select.select
+          multiselect vimgrep-select.multiselect
+          views [(snap.get :preview.vimgrep)]]
+      (snap.run {: prompt : layout : producer : select : multiselect : views}))))
 

--- a/fnl/snap/defaults/init.fnl
+++ b/fnl/snap/defaults/init.fnl
@@ -44,6 +44,7 @@
 (fn file-prompt-by-type [type]
   (match type
     :ripgrep.file "Rg Files"
+    :fd.file "Fd Files"
     :vim.oldfile "Old Files"
     :vim.buffer "Buffers"
     :git.file "Git Files"
@@ -55,6 +56,7 @@
   Supported producers:
 
   - ripgrep.file
+  - fd.file
   - vim.oldfile
   - vim.buffer
   - git.file

--- a/fnl/snap/defaults/init.fnl
+++ b/fnl/snap/defaults/init.fnl
@@ -2,8 +2,8 @@
                                 tbl snap.common.tbl}
                        require-macros [snap.macros]})
 
-(fn create-prompt [prefix prompt]
-  (string.format "%s%s" prompt (or prefix :>)))
+(fn create-prompt [suffix prompt]
+  (string.format "%s%s" prompt (or suffix :>)))
 
 (fn with [type defaults]
   "Returns a new default with config pre-applied.
@@ -73,7 +73,7 @@
   - args
   - layout
   - prompt
-  - prefix
+  - suffix
 
   Examples:
 
@@ -148,8 +148,8 @@
     (where c (= (type c) :function)) c
     _ (assert false "file.consumer is invalid")))
 
-  ;; Defaults in the user defined prefix
-  (local create-prompt (partial create-prompt config.prefix))
+  ;; Defaults in the user defined suffix
+  (local create-prompt (partial create-prompt config.suffix))
 
   ;; Create reasonable prompts based on types
   (local prompt (if
@@ -212,8 +212,8 @@
       (partial (snap.get :consumer.limit) config.limit)
       (fn [producer] producer)))
 
-  ;; Defaults in the user defined prefix
-  (local create-prompt (partial create-prompt config.prefix))
+  ;; Defaults in the user defined suffix
+  (local create-prompt (partial create-prompt config.suffix))
 
   ;; Get a reasonable default prompt based on types
   (local prompt (if

--- a/fnl/snap/defaults/init.fnl
+++ b/fnl/snap/defaults/init.fnl
@@ -2,21 +2,54 @@
                                 tbl snap.common.tbl}
                        require-macros [snap.macros]})
 
-(defn with [type defaults]
+(fn create-prompt [prefix prompt]
+  (string.format "%s%s" prompt (or prefix :>)))
+
+(fn with [type defaults]
   "Returns a new default with config pre-applied.
 
   If for example you prefer fzy over fzf, that is you don't like the common default, then:
 
   -- This creates a version of snap.defaults.file with fzy set as the default consumer:
-  local file = defaults.with(defaults.file, {consumer = 'fzy'})
+  local file = defaults.file:with {consumer = 'fzy'}
 
   -- Adds a mapping to search buffers
-  snap.map('n', '<Leader>b', file({producer = 'vim.buffer'}))
+  snap.map('n', '<Leader>b', file {producer = 'vim.buffer'})
 "
   (fn [config]
     (type (tbl.merge defaults config))))
 
-(defn file [config]
+(fn file-producer-by-type [config type]
+  "Gets a producer from producer type strings and handle special configs like args and hidden"
+  (var producer (match type
+    :ripgrep.file (snap.get :producer.ripgrep.file)
+    :fd.file (snap.get :producer.fd.file)
+    :vim.oldfile (snap.get :producer.vim.oldfile)
+    :vim.buffer (snap.get :producer.vim.buffer)
+    :git.file (snap.get :producer.git.file)
+    (where p (= (type p) :function)) p
+    _ (assert false "file.producer is invalid")))
+
+  ;; For ripgrep.file and fd.file set custom args or hidden
+  (when
+    (or (= type :ripgrep.file) (= type :fd.file))
+    (if
+      config.args
+      (set producer (producer.args config.args))
+      config.hidden
+      (set producer producer.hidden)))
+
+  producer)
+
+(fn file-prompt-by-type [type]
+  (match type
+    :ripgrep.file "Rg Files"
+    :vim.oldfile "Old Files"
+    :vim.buffer "Buffers"
+    :git.file "Git Files"
+    _ "Custom Files"))
+
+(defmetafn file {: with} [config]
   "Returns a functon which runs `snap.run` for searching files with common file producers and common consumers.
 
   Supported producers:
@@ -24,8 +57,8 @@
   - ripgrep.file
   - vim.oldfile
   - vim.buffer
-  - vim.help
   - git.file
+  - any producer function that returns files
 
   Supported consumers:
 
@@ -38,6 +71,7 @@
   - args
   - layout
   - prompt
+  - prefix
 
   Examples:
 
@@ -56,6 +90,9 @@
   -- Runs with git.file producer
   defaults.file {producer = 'git.file'}
 
+  -- Runs with git.file producer with ripgrep.file fallback
+  defaults.file {try = {'git.file', 'ripgrep.file}}
+
   -- Customizes prompt
   defaults.file {prompt = 'My Prompt>'}
 
@@ -73,30 +110,34 @@
   (assertfunction? config.layout "file.layout must be a function")
   (asserttable? config.args "file.args must be a table")
   (assertboolean? config.hidden "file.hidden must be a boolean")
+  (asserttable? config.try "file.try must be a table")
+  (asserttable? config.combine "file.combine must be a table")
 
-  ;; Get the producer type
-  (local producer-type (or config.producer :ripgrep.file))
+  ;; Ensure at least one producer config is set
+  (assert (or config.producer config.try config.combine) "one of file.producer, file.try or file.combine must be set")A
+
+  ;; Validate incompatible options
+  (assert (not (and config.producer config.try)) "file.try and file.producer can not be used together")
+  (assert (not (and config.producer config.combine)) "file.combine and file.producer can not be used together")
+  (assert (not (and config.try config.combine)) "file.try and file.combine can not be used together")
+  (assert (not (and config.hidden config.args)) "file.args and file.hidden can not be used together")
+
+  ;; Helper function with config applied
+  (local by-type (partial file-producer-by-type config))
   
   ;; Consumer type
   (local consumer-type (or config.consumer :fzf))
 
   ;; Get the initial producer module based on type
-  (var producer (match producer-type
-    :ripgrep.file (snap.get :producer.ripgrep.file)
-    :vim.oldfile (snap.get :producer.vim.oldfile)
-    :vim.buffer (snap.get :producer.vim.buffer)
-    :git.file (snap.get :producer.git.file)
-    (where p (= (type p) :function)) p
-    _ (assert false "file.producer is invalid")))
-
-  ;; For ripgrep.file set custom args or hidden
-  (when
-    (= producer-type :ripgrep.file)
-    (if
-      config.args
-      (set producer (producer.args config.args))
-      config.hidden
-      (set producer producer.hidden)))
+  (local producer (if
+    ;; If we are using try
+    config.try
+    ((snap.get :consumer.try) (unpack (vim.tbl_map by-type config.try)))
+    ;; If we are using combine
+    config.combine
+    ((snap.get :consumer.combine) (unpack (vim.tbl_map by-type config.combine)))
+    ;; Otherwise producer must be set
+    (by-type config.producer)))
 
   ;; Get the consumer module based on type
   (local consumer (match consumer-type
@@ -105,27 +146,38 @@
     (where c (= (type c) :function)) c
     _ (assert false "file.consumer is invalid")))
 
+  ;; Defaults in the user defined prefix
+  (local create-prompt (partial create-prompt config.prefix))
+
   ;; Create reasonable prompts based on types
-  (local prompt (or config.prompt (match producer-type
-    :ripgrep.file :Files>
-    :vim.oldfile "Old Files>"
-    :vim.buffer :Buffers>
-    :git.file "Git Files>"
-    _ "Files>")))
+  (local prompt (if
+    config.prompt
+    (create-prompt config.prompt)
+    config.producer
+    (create-prompt (file-prompt-by-type config.producer))
+    config.try
+    (create-prompt (table.concat (vim.tbl_map file-prompt-by-type config.try) " or "))
+    config.combine
+    (create-prompt (table.concat (vim.tbl_map file-prompt-by-type config.combine) " + "))))
 
   ;; Get the select module
   (local select (snap.get :select.file))
 
   ;; Create a function to invoke snap
   (fn [] (snap.run {: prompt
-                        :reverse (or config.reverse false)
-                        :layout (or config.layout nil)
-                        :producer (consumer producer)
-                        :select select.select
-                        :multiselect select.multiselect
-                        :views [(snap.get :preview.file)]})))
+                    :reverse (or config.reverse false)
+                    :layout (or config.layout nil)
+                    :producer (consumer producer)
+                    :select select.select
+                    :multiselect select.multiselect
+                    :views [(snap.get :preview.file)]})))
 
-(defn vimgrep [config]
+(fn vimgrep-prompt-by-type [type]
+  (match type
+    :ripgrep.vimgrep "Rg Vimgrep"
+    _ "Custom Vimgrep"))
+
+(defmetafn vimgrep {: with} [config]
   (asserttable config)
   (assertstring? config.prompt "vimgrep.prompt must be a string")
   (assertnumber? config.limit "vimgrep.limit must be a number")
@@ -158,10 +210,20 @@
       (partial (snap.get :consumer.limit) config.limit)
       (fn [producer] producer)))
 
+  ;; Defaults in the user defined prefix
+  (local create-prompt (partial create-prompt config.prefix))
+
+  ;; Get a reasonable default prompt based on types
+  (local prompt (if
+    config.prompt
+    (create-prompt config.prompt)
+    producer-type
+    (create-prompt (vimgrep-prompt-by-type producer-type))))
+
   ;; Get the select module
   (local select (snap.get :select.vimgrep))
 
-  (fn [] (snap.run {:prompt (or config.prompt :Grep>)
+  (fn [] (snap.run {: prompt
                     :layout (or config.layout nil)
                     :producer (consumer producer)
                     :select select.select

--- a/fnl/snap/init.fnl
+++ b/fnl/snap/init.fnl
@@ -21,6 +21,7 @@
 
 (module snap {require {tbl      snap.common.tbl
                        register snap.common.register
+                       config   snap.config
                        buffer   snap.common.buffer
                        window   snap.common.window
                        input    snap.view.input
@@ -32,6 +33,9 @@
 
 ;; Exposes register as a main API
 (def register register)
+
+;; Exposes config as a main API
+(def config config)
 
 (defn map [key run command]
   "Creates a mapping and an optional command name"
@@ -169,6 +173,7 @@
   (assertfunction? config.multiselect "snap.run 'multiselect' must be a function")
   (assertstring? config.prompt "snap.run 'prompt' must be a string")
   (assertfunction? config.layout "snap.run 'layout' must be a function")
+  (asserttypes? [:boolean :function] config.hide-views "snap.run 'hide-views' must be a boolean or a function")
   (asserttable? config.views "snap.run 'views' must be a table")
   (when config.views
     (each [_ view (ipairs config.views)]
@@ -210,8 +215,19 @@
   ;; Store the cursor row
   (var cursor-row 1)
 
-  ;; Allows the toggling of hide views
-  (var hide-views false)
+  ;; Starts as nil until manually overridden
+  (var hide-views nil)
+
+  ;; Computes default value or if hide-views is manually set then use that
+  (fn get-hide-views []
+    (if
+      (not= hide-views nil)
+      hide-views
+      (not= config.hide-views nil)
+      (match (type config.hide-views)
+        :function (config.hide-views)
+        :boolean config.hide-views)
+      false))
 
   ;; Vars for storing all views
   (var input-view nil)
@@ -248,7 +264,10 @@
   (local total-views (if config.views (length config.views) 0))
 
   ;; Dynamic because we can hide and show views
-  (fn has-views [] (and (not hide-views) (> total-views 0)))
+  (fn has-views []
+    (and
+      (> total-views 0)
+      (not (get-hide-views))))
 
   ;; Views need to be recreated when we hide/show
   (fn create-views []
@@ -261,17 +280,11 @@
   (create-views)
 
   ;; Creates the results buffer and window and stores thier numbers
-  (set results-view (results.create {: layout : has-views}))
+  (set results-view (results.create {: layout : has-views :reverse config.reverse}))
 
-  ;; Tracks size of partial results
-  (var partial-results-length 1)
   ;; Helper to update cursor
   (fn update-cursor []
-    (if config.reverse
-      (do
-        (vim.api.nvim_win_set_cursor results-view.winnr [(- partial-results-length (- cursor-row 1)) 0])
-        (vim.api.nvim_win_call results-view.winnr (partial vim.api.nvim_command "silent normal zb")))
-      (vim.api.nvim_win_set_cursor results-view.winnr [cursor-row 0])))
+    (vim.api.nvim_win_set_cursor results-view.winnr [cursor-row 0]))
 
   ;; Updates the views based on selection
   (safedebounced update-views [selection]
@@ -294,7 +307,6 @@
           ;; If there are no results then clear
           (do
            (buffer.set-lines results-view.bufnr 0 -1 [])
-           (set partial-results-length 1)
            (update-cursor))
           ;; Otherwise render partial results
           ;; Don't render more than we need to
@@ -304,26 +316,6 @@
             (each [_ result (ipairs results)
                    :until (= max (length partial-results))]
               (table.insert partial-results (tostring result)))
-
-            ;; Update length
-            (set partial-results-length (length partial-results))
-
-            ;; Reverse the results
-            (when config.reverse
-              (when (< partial-results-length results-view.height)
-                (for [_ partial-results-length results-view.height]
-                  (table.insert partial-results "")))
-
-              ;; Include the empty buffer lines in the length
-              (set partial-results-length (length partial-results))
-
-              ;; Reorder the table
-              (for [left-index 1 (math.floor (/ partial-results-length 2))]
-                (let [left (. partial-results left-index)
-                      right-index (- partial-results-length (- left-index 1))
-                      right (. partial-results right-index)]
-                  (tset partial-results left-index right)
-                  (tset partial-results right-index left))))
             ;; Set the lines, but make sure tables are converted to strings
             (buffer.set-lines results-view.bufnr 0 -1 partial-results)
             ;; Make sure the cursor is always updated
@@ -331,13 +323,12 @@
             ;; Update highlights
             (each [row (pairs partial-results)]
               (local result (. results row))
-              (local reverse-handled-row (if config.reverse (- partial-results-length (- row 1)) row))
               ;; Add positions highlighting
               (when
                 (has_meta result :positions)
                 (buffer.add-positions-highlight
                   results-view.bufnr
-                  reverse-handled-row
+                  row
                   (match (type result.positions)
                     :table result.positions
                     :function (result:positions)
@@ -345,7 +336,7 @@
               ;; Add selected highlighting
               (when
                 (. selected (tostring result))
-                (buffer.add-selected-highlight results-view.bufnr reverse-handled-row))))))
+                (buffer.add-selected-highlight results-view.bufnr row))))))
 
       ;; When we are running views schedule them
       (local selection (get-selection))
@@ -541,7 +532,10 @@
          (run next-config)))))
 
   (fn on-view-toggle-hide []
-    (set hide-views (not hide-views))
+    (set hide-views (if
+      (= hide-views nil)
+      (not (get-hide-views))
+      (not hide-views)))
     (results-view:update)
     (input-view:update)
     (if hide-views

--- a/fnl/snap/init.fnl
+++ b/fnl/snap/init.fnl
@@ -33,13 +33,18 @@
 ;; Exposes register as a main API
 (def register register)
 
-(defn map [key fnc command]
+(defn map [key run command]
   "Creates a mapping and an optional command name"
   (assertstring key "map key argument must be a string")
-  (assertfunction fnc "map fnc argument must be a function")
+  (assertfunction run "map run argument must be a function")
   (assertstring? command "map command argument must be a string")
-  (register.map :n key fnc)
-  (when command (register.command command fnc)))
+  (register.map :n key run)
+  (when command (register.command command run)))
+
+(defn maps [config]
+  "Creates mappings"
+  (each [_ [key run command] (ipairs config)]
+    (map key run command)))
 
 (defn get_producer [producer]
   "When a producer is a table, pull the default function out of it"

--- a/fnl/snap/init.fnl
+++ b/fnl/snap/init.fnl
@@ -33,6 +33,14 @@
 ;; Exposes register as a main API
 (def register register)
 
+(defn map [key fnc command]
+  "Creates a mapping and an optional command name"
+  (assertstring key "map key argument must be a string")
+  (assertfunction fnc "map fnc argument must be a function")
+  (assertstring? command "map command argument must be a string")
+  (register.map :n key fnc)
+  (when command (register.command command fnc)))
+
 (defn get_producer [producer]
   "When a producer is a table, pull the default function out of it"
   (match (type producer)

--- a/fnl/snap/layout/init.fnl
+++ b/fnl/snap/layout/init.fnl
@@ -50,7 +50,12 @@
   (%centered 0.9 0.7))
 
 (defn bottom []
-  (%bottom 0.9 0.7))
+  (let [lines (vim.api.nvim_get_option :lines)
+        height (math.floor (* lines 0.5))
+        width (- (vim.api.nvim_get_option :columns) 4)
+        col 0
+        row (- lines height 4)]
+    {: width : height : col : row }))
 
 (defn top []
   (%top 0.9 0.7))

--- a/fnl/snap/layout/init.fnl
+++ b/fnl/snap/layout/init.fnl
@@ -52,7 +52,7 @@
 (defn bottom []
   (let [lines (vim.api.nvim_get_option :lines)
         height (math.floor (* lines 0.5))
-        width (- (vim.api.nvim_get_option :columns) 4)
+        width (vim.api.nvim_get_option :columns)
         col 0
         row (- lines height 4)]
     {: width : height : col : row }))

--- a/fnl/snap/macros.fnl
+++ b/fnl/snap/macros.fnl
@@ -2,6 +2,10 @@
 (fn safefn [name ...]
   `(local ,name (vim.schedule_wrap (fn ,...))))
 
+;; Defines a metafunction
+(fn defmetafn [name tbl ...]
+  `(def ,name (setmetatable ,tbl {:__call (fn [self# ...] ((fn ,...) ...))})))
+
 ;; Calls a non-fast mode function safely
 (fn safecall [fnc ...]
   `((vim.schedule_wrap ,fnc) ,...))
@@ -77,6 +81,7 @@
 {: safefn
  : safecall
  : safedebounced
+ : defmetafn
  : asserttype
  : asserttype?
  : assertfunction

--- a/fnl/snap/macros.fnl
+++ b/fnl/snap/macros.fnl
@@ -33,6 +33,12 @@
            ;; so just swap the args to be called with
            (set args# [...]))))))
 
+(fn asserttypes [types value msg]
+  `(assert (vim.tbl_contains ,types (type ,value)) ,msg))
+
+(fn asserttypes? [types value msg]
+  `(when ,value (asserttypes ,types ,value ,msg)))
+
 (fn asserttype [typ value msg]
   `(assert (= (type ,value) ,typ) ,msg))
 
@@ -82,6 +88,8 @@
  : safecall
  : safedebounced
  : defmetafn
+ : asserttypes
+ : asserttypes?
  : asserttype
  : asserttype?
  : assertfunction

--- a/fnl/snap/macros.fnl
+++ b/fnl/snap/macros.fnl
@@ -65,6 +65,12 @@
 (fn assertboolean? [value msg]
   `(asserttype? :boolean ,value ,msg))
 
+(fn assertnumber [value msg]
+  `(asserttype :number ,value ,msg))
+
+(fn assertnumber? [value msg]
+  `(asserttype? :number ,value ,msg))
+
 (fn assertmetatable [value metatable msg]
   `(assert (= (getmetatable ,value) ,metatable) ,msg))
 
@@ -83,4 +89,6 @@
  : assertthread?
  : assertboolean
  : assertboolean?
+ : assertnumber
+ : assertnumber?
  : assertmetatable}

--- a/fnl/snap/producer/ripgrep/vimgrep.fnl
+++ b/fnl/snap/producer/ripgrep/vimgrep.fnl
@@ -6,6 +6,9 @@
   (fn vimgrep.default [request]
     (let [cwd (snap.sync vim.fn.getcwd)]
       (general request {:args (tbl.concat args [request.filter]) : cwd})))
+  (fn vimgrep.hidden [request]
+    (let [cwd (snap.sync vim.fn.getcwd)]
+      (general request {:args (tbl.concat args [:--hidden request.filter]) : cwd})))
   (fn vimgrep.args [new-args cwd]
     (let [args (tbl.concat args new-args)
           absolute (not= cwd nil)]

--- a/fnl/snap/view/input.fnl
+++ b/fnl/snap/view/input.fnl
@@ -7,9 +7,9 @@
 (fn layout [config]
   "Creates the input layout"
   (let [{: width : height : row : col} (config.layout)]
-    {:width (if (config.has-views) (math.floor (* width size.view-width)) width)
+    {:width (if (config.has-views) (- (math.floor (* width size.view-width)) size.padding size.padding) width)
      :height 1
-     :row (- (+ row height) size.padding)
+     :row (if config.reverse row (- (+ row height) size.padding))
      : col
      :focusable true}))
 
@@ -23,10 +23,10 @@
   :select [:<Tab>]
   :unselect [:<S-Tab>]
   :select-all [:<C-a>]
-  :prev-item [:<C-p>]
-  :next-item [:<C-n>]
-  :prev-page [:<C-b>]
-  :next-page [:<C-f>]
+  :prev-item [:<C-p> :<Up> :<C-k>]
+  :next-item [:<C-n> :<Down> :<C-j>]
+  :prev-page [:<C-b> :<PageUp>]
+  :next-page [:<C-f> :<PageDown]
   :view-page-down [:<C-d>]
   :view-page-up [:<C-u>]
   :view-toggle-hide [:<C-h>]
@@ -100,14 +100,10 @@
     (register.buf-map bufnr [:n :i] mappings.select-all on-ctrla)
 
     ;; Up & down are reversed when view is revered
-    (register.buf-map bufnr [:n :i] (if config.reverse [:<Down> :<C-j>] [:<Up> :<C-k>]) config.on-prev-item)
-    (register.buf-map bufnr [:n :i] (if config.reverse [:<Up> :<C-k>]  [:<Down> :<C-j>]) config.on-next-item)
     (register.buf-map bufnr [:n :i] mappings.prev-item config.on-prev-item)
     (register.buf-map bufnr [:n :i] mappings.next-item config.on-next-item)
 
     ;; Up & down are reversed when view is revered
-    (register.buf-map bufnr [:n :i] (if config.reverse [:<PageDown>] [:<PageUp>]) config.on-prev-page)
-    (register.buf-map bufnr [:n :i] (if config.reverse [:<PageUp>]  [:<PageDown>]) config.on-next-page)
     (register.buf-map bufnr [:n :i] mappings.prev-page config.on-prev-page)
     (register.buf-map bufnr [:n :i] mappings.next-page config.on-next-page)
 

--- a/fnl/snap/view/results.fnl
+++ b/fnl/snap/view/results.fnl
@@ -6,9 +6,9 @@
 (fn layout [config]
   "Creates the results layout"
   (let [{: width : height : row : col} (config.layout)]
-    {:width (if (config.has-views) (math.floor (* width size.view-width)) width)
+    {:width (if (config.has-views) (- (math.floor (* width size.view-width)) size.padding size.padding) width)
      :height (- height size.border size.border size.padding)
-     : row
+     :row (if config.reverse (+ row size.border size.padding size.padding) row)
      : col
      :focusable false}))
 
@@ -34,6 +34,7 @@
     (fn update [view]
       (let [layout-config (layout config)]
         (window.update winnr layout-config)
+        (vim.api.nvim_win_set_option winnr :cursorline true)
         (tset view :height layout-config.height)
         (tset view :width layout-config.width)))
 

--- a/fnl/snap/view/view.fnl
+++ b/fnl/snap/view/view.fnl
@@ -15,7 +15,7 @@
         sizes (tbl.allocate (- height total-borders total-paddings) config.total-views)
         height (. sizes config.index)
         col-offset (math.floor (* width size.view-width))]
-    {:width (- width col-offset)
+    {:width (- width col-offset size.padding size.padding size.border)
      : height
      :row (+ row (tbl.sum (tbl.take sizes index)) border padding)
      :col (+ col col-offset (* size.border 2) size.padding)

--- a/lua/snap/common/register.lua
+++ b/lua/snap/common/register.lua
@@ -39,7 +39,7 @@ local _local_0_ = _2_(...)
 local _2amodule_2a = _0_
 local _2amodule_name_2a = "snap.common.register"
 do local _ = ({nil, _0_, nil, {{}, nil, nil, nil}})[2] end
-local register = {}
+local register = {commands = {}}
 local clean
 do
   local v_0_
@@ -191,5 +191,31 @@ do
   local t_0_ = (_0_)["aniseed/locals"]
   t_0_["map"] = v_0_
   map = v_0_
+end
+_G.snap_commands = function()
+  return vim.tbl_keys(register.commands)
+end
+local command
+do
+  local v_0_
+  do
+    local v_0_0
+    local function command0(name, fnc)
+      if (#register.commands == 0) then
+        vim.api.nvim_command("command! -nargs=1 -complete=customlist,v:lua.snap_commands Snap lua require'snap'.register.run('commands', <f-args>)")
+      end
+      if (register.commands[name] ~= nil) then
+        assert(false, string.format("attempting to register duplicate command with name '%s'", name))
+      end
+      register.commands[name] = fnc
+      return nil
+    end
+    v_0_0 = command0
+    _0_["command"] = v_0_0
+    v_0_ = v_0_0
+  end
+  local t_0_ = (_0_)["aniseed/locals"]
+  t_0_["command"] = v_0_
+  command = v_0_
 end
 return nil

--- a/lua/snap/config/init.lua
+++ b/lua/snap/config/init.lua
@@ -45,6 +45,16 @@ local default_min_width = (80 * 2)
 local function preview_disabled(min_width)
   return (vim.api.nvim_get_option("columns") <= (min_width or default_min_width))
 end
+local function hide_views(config)
+  local _3_ = type(config.preview)
+  if (_3_ == "nil") then
+    return preview_disabled(config["preview-min-width"])
+  elseif (_3_ == "boolean") then
+    return ((config.preview == false) or preview_disabled(config["preview-min-width"]))
+  elseif (_3_ == "function") then
+    return not config.preview()
+  end
+end
 local function format_prompt(suffix, prompt)
   return string.format("%s%s", prompt, (suffix or ">"))
 end
@@ -205,26 +215,21 @@ do
         end
         prompt = add_prompt_suffix(_19_())
         local select_file = snap.get("select.file")
-        local function hide_views()
-          local _20_ = type(config.preview)
-          if (_20_ == "nil") then
-            return preview_disabled(config["preview-min-width"])
-          elseif (_20_ == "boolean") then
-            return ((config.preview == false) or preview_disabled(config["preview-min-width"]))
-          elseif (_20_ == "function") then
-            return not config.preview()
-          end
+        local hide_views0
+        local function _20_(...)
+          return hide_views(config, ...)
         end
-        local function _20_()
+        hide_views0 = _20_
+        local function _21_()
           local reverse = (config.reverse or false)
           local layout = (config.layout or nil)
           local producer0 = consumer(producer)
           local select = select_file.select
           local multiselect = select_file.multiselect
           local views = {snap.get("preview.file")}
-          return snap.run({["hide-views"] = hide_views, layout = layout, multiselect = multiselect, producer = producer0, prompt = prompt, reverse = reverse, select = select, views = views})
+          return snap.run({["hide-views"] = hide_views0, layout = layout, multiselect = multiselect, producer = producer0, prompt = prompt, reverse = reverse, select = select, views = views})
         end
-        return _20_
+        return _21_
       end
       return _4_(...)
     end
@@ -331,25 +336,19 @@ do
         end
         prompt = format_prompt0(_17_())
         local vimgrep_select = snap.get("select.vimgrep")
-        local preview
-        if (config.preview ~= nil) then
-          preview = config.preview
-        else
-          preview = true
+        local hide_views0
+        local function _18_(...)
+          return hide_views(config, ...)
         end
+        hide_views0 = _18_
         local function _19_()
           local reverse = (config.reverse or false)
           local layout = (config.layout or nil)
           local producer0 = consumer(producer)
           local select = vimgrep_select.select
           local multiselect = vimgrep_select.multiselect
-          local views
-          if preview then
-            views = {snap.get("preview.vimgrep")}
-          else
-            views = nil
-          end
-          return snap.run({layout = layout, multiselect = multiselect, producer = producer0, prompt = prompt, select = select, views = views})
+          local views = {snap.get("preview.vimgrep")}
+          return snap.run({["hide-views"] = hide_views0, layout = layout, multiselect = multiselect, producer = producer0, prompt = prompt, select = select, views = views})
         end
         return _19_
       end

--- a/lua/snap/config/init.lua
+++ b/lua/snap/config/init.lua
@@ -1,7 +1,7 @@
-local _2afile_2a = "fnl/snap/defaults/init.fnl"
+local _2afile_2a = "fnl/snap/config/init.fnl"
 local _0_
 do
-  local name_0_ = "snap.defaults"
+  local name_0_ = "snap.config"
   local module_0_
   do
     local x_0_ = package.loaded[name_0_]
@@ -39,7 +39,7 @@ local _local_0_ = _2_(...)
 local snap = _local_0_[1]
 local tbl = _local_0_[2]
 local _2amodule_2a = _0_
-local _2amodule_name_2a = "snap.defaults"
+local _2amodule_name_2a = "snap.config"
 do local _ = ({nil, _0_, nil, {{nil}, nil, nil, nil}})[2] end
 local function format_prompt(suffix, prompt)
   return string.format("%s%s", prompt, (suffix or ">"))

--- a/lua/snap/config/init.lua
+++ b/lua/snap/config/init.lua
@@ -153,6 +153,9 @@ do
         if config["preview-min-width"] then
           assert((type(config["preview-min-width"]) == "number"), "file.preview-min-with must be a boolean")
         end
+        if config.mappings then
+          assert((type(config.mappings) == "table"), "file.mappings must be a table")
+        end
         if config.preview then
           assert(vim.tbl_contains({"function", "boolean"}, type(config.preview)), "file.preview must be a boolean or a function")
         end
@@ -162,10 +165,10 @@ do
         assert(not (config.try and config.combine), "file.try and file.combine can not be used together")
         assert(not (config.hidden and config.args), "file.args and file.hidden can not be used together")
         local by_kind
-        local function _15_(...)
+        local function _16_(...)
           return file_producer_by_kind(config, ...)
         end
-        by_kind = _15_
+        by_kind = _16_
         local consumer_kind = (config.consumer or "fzf")
         local producer
         if config.try then
@@ -177,32 +180,32 @@ do
         end
         local consumer
         do
-          local _17_ = consumer_kind
-          if (_17_ == "fzf") then
+          local _18_ = consumer_kind
+          if (_18_ == "fzf") then
             consumer = snap.get("consumer.fzf")
-          elseif (_17_ == "fzy") then
+          elseif (_18_ == "fzy") then
             consumer = snap.get("consumer.fzy")
           else
-            local function _18_()
-              local c = _17_
+            local function _19_()
+              local c = _18_
               return (type(c) == "function")
             end
-            if ((nil ~= _17_) and _18_()) then
-              local c = _17_
+            if ((nil ~= _18_) and _19_()) then
+              local c = _18_
               consumer = c
             else
-              local _ = _17_
+              local _ = _18_
               consumer = assert(false, "file.consumer is invalid")
             end
           end
         end
         local add_prompt_suffix
-        local function _18_(...)
+        local function _19_(...)
           return format_prompt(config.suffix, ...)
         end
-        add_prompt_suffix = _18_
+        add_prompt_suffix = _19_
         local prompt
-        local function _19_()
+        local function _20_()
           if config.prompt then
             return config.prompt
           elseif config.producer then
@@ -213,21 +216,22 @@ do
             return table.concat(vim.tbl_map(file_prompt_by_kind, config.combine), " + ")
           end
         end
-        prompt = add_prompt_suffix(_19_())
+        prompt = add_prompt_suffix(_20_())
         local select_file = snap.get("select.file")
-        local hide_views0
-        local function _20_(...)
-          return hide_views(config, ...)
-        end
-        hide_views0 = _20_
         local function _21_()
+          local hide_views0
+          local function _22_(...)
+            return hide_views(config, ...)
+          end
+          hide_views0 = _22_
           local reverse = (config.reverse or false)
           local layout = (config.layout or nil)
+          local mappings = (config.mappings or nil)
           local producer0 = consumer(producer)
           local select = select_file.select
           local multiselect = select_file.multiselect
           local views = {snap.get("preview.file")}
-          return snap.run({["hide-views"] = hide_views0, layout = layout, multiselect = multiselect, producer = producer0, prompt = prompt, reverse = reverse, select = select, views = views})
+          return snap.run({["hide-views"] = hide_views0, layout = layout, mappings = mappings, multiselect = multiselect, producer = producer0, prompt = prompt, reverse = reverse, select = select, views = views})
         end
         return _21_
       end
@@ -282,22 +286,25 @@ do
         if config.preview then
           assert((type(config.preview) == "boolean"), "vimgrep.preview must be a boolean")
         end
+        if config.mappings then
+          assert((type(config.mappings) == "table"), "vimgrep.mappings must be a table")
+        end
         local producer_kind = (config.producer or "ripgrep.vimgrep")
         local producer
         do
-          local _13_ = producer_kind
-          if (_13_ == "ripgrep.vimgrep") then
+          local _14_ = producer_kind
+          if (_14_ == "ripgrep.vimgrep") then
             producer = snap.get("producer.ripgrep.vimgrep")
           else
-            local function _14_()
-              local p = _13_
+            local function _15_()
+              local p = _14_
               return (type(p) == "function")
             end
-            if ((nil ~= _13_) and _14_()) then
-              local p = _13_
+            if ((nil ~= _14_) and _15_()) then
+              local p = _14_
               producer = p
             else
-              local _ = _13_
+              local _ = _14_
               producer = assert(false, "vimgrep.producer is invalid")
             end
           end
@@ -311,44 +318,45 @@ do
         end
         local consumer
         if config.limit then
-          local function _15_(...)
+          local function _16_(...)
             return snap.get("consumer.limit")(config.limit, ...)
           end
-          consumer = _15_
+          consumer = _16_
         else
-          local function _15_(producer0)
+          local function _16_(producer0)
             return producer0
           end
-          consumer = _15_
+          consumer = _16_
         end
         local format_prompt0
-        local function _16_(...)
+        local function _17_(...)
           return format_prompt(config.suffix, ...)
         end
-        format_prompt0 = _16_
+        format_prompt0 = _17_
         local prompt
-        local function _17_()
+        local function _18_()
           if config.prompt then
             return config.prompt
           elseif producer_kind then
             return vimgrep_prompt_by_kind(producer_kind)
           end
         end
-        prompt = format_prompt0(_17_())
+        prompt = format_prompt0(_18_())
         local vimgrep_select = snap.get("select.vimgrep")
-        local hide_views0
-        local function _18_(...)
-          return hide_views(config, ...)
-        end
-        hide_views0 = _18_
         local function _19_()
+          local hide_views0
+          local function _20_(...)
+            return hide_views(config, ...)
+          end
+          hide_views0 = _20_
           local reverse = (config.reverse or false)
           local layout = (config.layout or nil)
+          local mappings = (config.mappings or nil)
           local producer0 = consumer(producer)
           local select = vimgrep_select.select
           local multiselect = vimgrep_select.multiselect
           local views = {snap.get("preview.vimgrep")}
-          return snap.run({["hide-views"] = hide_views0, layout = layout, multiselect = multiselect, producer = producer0, prompt = prompt, select = select, views = views})
+          return snap.run({["hide-views"] = hide_views0, layout = layout, mappings = mappings, multiselect = multiselect, producer = producer0, prompt = prompt, select = select, views = views})
         end
         return _19_
       end

--- a/lua/snap/defaults/init.lua
+++ b/lua/snap/defaults/init.lua
@@ -44,16 +44,16 @@ do local _ = ({nil, _0_, nil, {{nil}, nil, nil, nil}})[2] end
 local function create_prompt(suffix, prompt)
   return string.format("%s%s", prompt, (suffix or ">"))
 end
-local function with(type, defaults)
+local function with(fnc, defaults)
   local function _3_(config)
-    return type(tbl.merge(defaults, config))
+    return fnc(tbl.merge(defaults, config))
   end
   return _3_
 end
-local function file_producer_by_type(config, type)
+local function file_producer_by_kind(config, kind)
   local producer
   do
-    local _3_ = type
+    local _3_ = kind
     if (_3_ == "ripgrep.file") then
       producer = snap.get("producer.ripgrep.file")
     elseif (_3_ == "fd.file") then
@@ -78,7 +78,7 @@ local function file_producer_by_type(config, type)
       end
     end
   end
-  if ((type == "ripgrep.file") or (type == "fd.file")) then
+  if ((kind == "ripgrep.file") or (kind == "fd.file")) then
     if config.args then
       producer = producer.args(config.args)
     elseif config.hidden then
@@ -87,7 +87,7 @@ local function file_producer_by_type(config, type)
   end
   return producer
 end
-local function file_prompt_by_type(type)
+local function file_prompt_by_kind(type)
   local _3_ = type
   if (_3_ == "ripgrep.file") then
     return "Rg Files"
@@ -135,23 +135,23 @@ do
         assert(not (config.producer and config.combine), "file.combine and file.producer can not be used together")
         assert(not (config.try and config.combine), "file.try and file.combine can not be used together")
         assert(not (config.hidden and config.args), "file.args and file.hidden can not be used together")
-        local by_type
+        local by_kind
         local function _11_(...)
-          return file_producer_by_type(config, ...)
+          return file_producer_by_kind(config, ...)
         end
-        by_type = _11_
-        local consumer_type = (config.consumer or "fzf")
+        by_kind = _11_
+        local consumer_kind = (config.consumer or "fzf")
         local producer
         if config.try then
-          producer = snap.get("consumer.try")(unpack(vim.tbl_map(by_type, config.try)))
+          producer = snap.get("consumer.try")(unpack(vim.tbl_map(by_kind, config.try)))
         elseif config.combine then
-          producer = snap.get("consumer.combine")(unpack(vim.tbl_map(by_type, config.combine)))
+          producer = snap.get("consumer.combine")(unpack(vim.tbl_map(by_kind, config.combine)))
         else
-          producer = by_type(config.producer)
+          producer = by_kind(config.producer)
         end
         local consumer
         do
-          local _13_ = consumer_type
+          local _13_ = consumer_kind
           if (_13_ == "fzf") then
             consumer = snap.get("consumer.fzf")
           elseif (_13_ == "fzy") then
@@ -179,11 +179,11 @@ do
         if config.prompt then
           prompt = create_prompt0(config.prompt)
         elseif config.producer then
-          prompt = create_prompt0(file_prompt_by_type(config.producer))
+          prompt = create_prompt0(file_prompt_by_kind(config.producer))
         elseif config.try then
-          prompt = create_prompt0(table.concat(vim.tbl_map(file_prompt_by_type, config.try), " or "))
+          prompt = create_prompt0(table.concat(vim.tbl_map(file_prompt_by_kind, config.try), " or "))
         elseif config.combine then
-          prompt = create_prompt0(table.concat(vim.tbl_map(file_prompt_by_type, config.combine), " + "))
+          prompt = create_prompt0(table.concat(vim.tbl_map(file_prompt_by_kind, config.combine), " + "))
         else
         prompt = nil
         end
@@ -203,8 +203,8 @@ do
   t_0_["file"] = v_0_
   file = v_0_
 end
-local function vimgrep_prompt_by_type(type)
-  local _3_ = type
+local function vimgrep_prompt_by_kind(kind)
+  local _3_ = kind
   if (_3_ == "ripgrep.vimgrep") then
     return "Rg Vimgrep"
   else
@@ -235,10 +235,10 @@ do
         if config.hidden then
           assert((type(config.hidden) == "boolean"), "vimgrep.hidden must be a boolean")
         end
-        local producer_type = (config.producer or "ripgrep.vimgrep")
+        local producer_kind = (config.producer or "ripgrep.vimgrep")
         local producer
         do
-          local _10_ = producer_type
+          local _10_ = producer_kind
           if (_10_ == "ripgrep.vimgrep") then
             producer = snap.get("producer.ripgrep.vimgrep")
           else
@@ -255,7 +255,7 @@ do
             end
           end
         end
-        if (producer_type == "ripgrep.vimgrep") then
+        if (producer_kind == "ripgrep.vimgrep") then
           if config.args then
             producer = producer.args(config.args)
           elseif config.hidden then
@@ -282,8 +282,8 @@ do
         local prompt
         if config.prompt then
           prompt = create_prompt0(config.prompt)
-        elseif producer_type then
-          prompt = create_prompt0(vimgrep_prompt_by_type(producer_type))
+        elseif producer_kind then
+          prompt = create_prompt0(vimgrep_prompt_by_kind(producer_kind))
         else
         prompt = nil
         end

--- a/lua/snap/defaults/init.lua
+++ b/lua/snap/defaults/init.lua
@@ -1,0 +1,243 @@
+local _2afile_2a = "fnl/snap/defaults/init.fnl"
+local _0_
+do
+  local name_0_ = "snap.defaults"
+  local module_0_
+  do
+    local x_0_ = package.loaded[name_0_]
+    if ("table" == type(x_0_)) then
+      module_0_ = x_0_
+    else
+      module_0_ = {}
+    end
+  end
+  module_0_["aniseed/module"] = name_0_
+  module_0_["aniseed/locals"] = ((module_0_)["aniseed/locals"] or {})
+  do end (module_0_)["aniseed/local-fns"] = ((module_0_)["aniseed/local-fns"] or {})
+  do end (package.loaded)[name_0_] = module_0_
+  _0_ = module_0_
+end
+local autoload
+local function _1_(...)
+  return (require("aniseed.autoload")).autoload(...)
+end
+autoload = _1_
+local function _2_(...)
+  local ok_3f_0_, val_0_ = nil, nil
+  local function _2_()
+    return {require("snap"), require("snap.common.tbl")}
+  end
+  ok_3f_0_, val_0_ = pcall(_2_)
+  if ok_3f_0_ then
+    _0_["aniseed/local-fns"] = {["require-macros"] = {["snap.macros"] = true}, require = {snap = "snap", tbl = "snap.common.tbl"}}
+    return val_0_
+  else
+    return print(val_0_)
+  end
+end
+local _local_0_ = _2_(...)
+local snap = _local_0_[1]
+local tbl = _local_0_[2]
+local _2amodule_2a = _0_
+local _2amodule_name_2a = "snap.defaults"
+do local _ = ({nil, _0_, nil, {{nil}, nil, nil, nil}})[2] end
+local with
+do
+  local v_0_
+  do
+    local v_0_0
+    local function with0(type, defaults)
+      local function _3_(config)
+        return type(tbl.merge(defaults, config))
+      end
+      return _3_
+    end
+    v_0_0 = with0
+    _0_["with"] = v_0_0
+    v_0_ = v_0_0
+  end
+  local t_0_ = (_0_)["aniseed/locals"]
+  t_0_["with"] = v_0_
+  with = v_0_
+end
+local file
+do
+  local v_0_
+  do
+    local v_0_0
+    local function file0(config)
+      assert((type(config) == "table"))
+      if config.prompt then
+        assert((type(config.prompt) == "string"), "file.prompt must be a string")
+      end
+      if config.layout then
+        assert((type(config.layout) == "function"), "file.layout must be a function")
+      end
+      if config.args then
+        assert((type(config.args) == "table"), "file.args must be a table")
+      end
+      if config.hidden then
+        assert((type(config.hidden) == "boolean"), "file.hidden must be a boolean")
+      end
+      local producer_type = (config.producer or "ripgrep.file")
+      local consumer_type = (config.consumer or "fzf")
+      local producer
+      do
+        local _7_ = producer_type
+        if (_7_ == "ripgrep.file") then
+          producer = snap.get("producer.ripgrep.file")
+        elseif (_7_ == "vim.oldfile") then
+          producer = snap.get("producer.vim.oldfile")
+        elseif (_7_ == "vim.buffer") then
+          producer = snap.get("producer.vim.buffer")
+        elseif (_7_ == "git.file") then
+          producer = snap.get("producer.git.file")
+        else
+          local function _8_()
+            local p = _7_
+            return (type(p) == "function")
+          end
+          if ((nil ~= _7_) and _8_()) then
+            local p = _7_
+            producer = p
+          else
+            local _ = _7_
+            producer = assert(false, "file.producer is invalid")
+          end
+        end
+      end
+      if (producer_type == "ripgrep.file") then
+        if config.args then
+          producer = producer.args(config.args)
+        elseif config.hidden then
+          producer = producer.hidden
+        end
+      end
+      local consumer
+      do
+        local _9_ = consumer_type
+        if (_9_ == "fzf") then
+          consumer = snap.get("consumer.fzf")
+        elseif (_9_ == "fzy") then
+          consumer = snap.get("consumer.fzy")
+        else
+          local function _10_()
+            local c = _9_
+            return (type(c) == "function")
+          end
+          if ((nil ~= _9_) and _10_()) then
+            local c = _9_
+            consumer = c
+          else
+            local _ = _9_
+            consumer = assert(false, "file.consumer is invalid")
+          end
+        end
+      end
+      local prompt
+      local function _11_()
+        local _10_ = producer_type
+        if (_10_ == "ripgrep.file") then
+          return "Files>"
+        elseif (_10_ == "vim.oldfile") then
+          return "Old Files>"
+        elseif (_10_ == "vim.buffer") then
+          return "Buffers>"
+        elseif (_10_ == "git.file") then
+          return "Git Files>"
+        else
+          local _ = _10_
+          return "Files>"
+        end
+      end
+      prompt = (config.prompt or _11_())
+      local select = snap.get("select.file")
+      local function _12_()
+        return snap.run({layout = (config.layout or nil), multiselect = select.multiselect, producer = consumer(producer), prompt = prompt, reverse = (config.reverse or false), select = select.select, views = {snap.get("preview.file")}})
+      end
+      return _12_
+    end
+    v_0_0 = file0
+    _0_["file"] = v_0_0
+    v_0_ = v_0_0
+  end
+  local t_0_ = (_0_)["aniseed/locals"]
+  t_0_["file"] = v_0_
+  file = v_0_
+end
+local vimgrep
+do
+  local v_0_
+  do
+    local v_0_0
+    local function vimgrep0(config)
+      assert((type(config) == "table"))
+      if config.prompt then
+        assert((type(config.prompt) == "string"), "vimgrep.prompt must be a string")
+      end
+      if config.limit then
+        assert((type(config.limit) == "number"), "vimgrep.limit must be a number")
+      end
+      if config.layout then
+        assert((type(config.layout) == "function"), "vimgrep.layout must be a function")
+      end
+      if config.args then
+        assert((type(config.args) == "table"), "vimgrep.args must be a table")
+      end
+      if config.hidden then
+        assert((type(config.hidden) == "boolean"), "vimgrep.hidden must be a boolean")
+      end
+      local producer_type = (config.producer or "ripgrep.vimgrep")
+      local producer
+      do
+        local _8_ = producer_type
+        if (_8_ == "ripgrep.vimgrep") then
+          producer = snap.get("producer.ripgrep.vimgrep")
+        else
+          local function _9_()
+            local p = _8_
+            return (type(p) == "function")
+          end
+          if ((nil ~= _8_) and _9_()) then
+            local p = _8_
+            producer = p
+          else
+            local _ = _8_
+            producer = assert(false, "vimgrep.producer is invalid")
+          end
+        end
+      end
+      if (producer_type == "ripgrep.vimgrep") then
+        if config.args then
+          producer = producer.args(config.args)
+        elseif config.hidden then
+          producer = producer.hidden
+        end
+      end
+      local consumer
+      if config.limit then
+        local function _10_(...)
+          return snap.get("consumer.limit")(config.limit, ...)
+        end
+        consumer = _10_
+      else
+        local function _10_(producer0)
+          return producer0
+        end
+        consumer = _10_
+      end
+      local select = snap.get("select.vimgrep")
+      local function _11_()
+        return snap.run({layout = (config.layout or nil), multiselect = select.multiselect, producer = consumer(producer), prompt = (config.prompt or "Grep>"), select = select.select, views = {snap.get("preview.vimgrep")}})
+      end
+      return _11_
+    end
+    v_0_0 = vimgrep0
+    _0_["vimgrep"] = v_0_0
+    v_0_ = v_0_0
+  end
+  local t_0_ = (_0_)["aniseed/locals"]
+  t_0_["vimgrep"] = v_0_
+  vimgrep = v_0_
+end
+return nil

--- a/lua/snap/defaults/init.lua
+++ b/lua/snap/defaults/init.lua
@@ -41,8 +41,8 @@ local tbl = _local_0_[2]
 local _2amodule_2a = _0_
 local _2amodule_name_2a = "snap.defaults"
 do local _ = ({nil, _0_, nil, {{nil}, nil, nil, nil}})[2] end
-local function create_prompt(prefix, prompt)
-  return string.format("%s%s", prompt, (prefix or ">"))
+local function create_prompt(suffix, prompt)
+  return string.format("%s%s", prompt, (suffix or ">"))
 end
 local function with(type, defaults)
   local function _3_(config)
@@ -172,7 +172,7 @@ do
         end
         local create_prompt0
         local function _14_(...)
-          return create_prompt(config.prefix, ...)
+          return create_prompt(config.suffix, ...)
         end
         create_prompt0 = _14_
         local prompt
@@ -276,7 +276,7 @@ do
         end
         local create_prompt0
         local function _13_(...)
-          return create_prompt(config.prefix, ...)
+          return create_prompt(config.suffix, ...)
         end
         create_prompt0 = _13_
         local prompt

--- a/lua/snap/defaults/init.lua
+++ b/lua/snap/defaults/init.lua
@@ -91,6 +91,8 @@ local function file_prompt_by_type(type)
   local _3_ = type
   if (_3_ == "ripgrep.file") then
     return "Rg Files"
+  elseif (_3_ == "fd.file") then
+    return "Fd Files"
   elseif (_3_ == "vim.oldfile") then
     return "Old Files"
   elseif (_3_ == "vim.buffer") then

--- a/lua/snap/defaults/init.lua
+++ b/lua/snap/defaults/init.lua
@@ -41,199 +41,260 @@ local tbl = _local_0_[2]
 local _2amodule_2a = _0_
 local _2amodule_name_2a = "snap.defaults"
 do local _ = ({nil, _0_, nil, {{nil}, nil, nil, nil}})[2] end
-local with
-do
-  local v_0_
-  do
-    local v_0_0
-    local function with0(type, defaults)
-      local function _3_(config)
-        return type(tbl.merge(defaults, config))
-      end
-      return _3_
-    end
-    v_0_0 = with0
-    _0_["with"] = v_0_0
-    v_0_ = v_0_0
+local function create_prompt(prefix, prompt)
+  return string.format("%s%s", prompt, (prefix or ">"))
+end
+local function with(type, defaults)
+  local function _3_(config)
+    return type(tbl.merge(defaults, config))
   end
-  local t_0_ = (_0_)["aniseed/locals"]
-  t_0_["with"] = v_0_
-  with = v_0_
+  return _3_
+end
+local function file_producer_by_type(config, type)
+  local producer
+  do
+    local _3_ = type
+    if (_3_ == "ripgrep.file") then
+      producer = snap.get("producer.ripgrep.file")
+    elseif (_3_ == "fd.file") then
+      producer = snap.get("producer.fd.file")
+    elseif (_3_ == "vim.oldfile") then
+      producer = snap.get("producer.vim.oldfile")
+    elseif (_3_ == "vim.buffer") then
+      producer = snap.get("producer.vim.buffer")
+    elseif (_3_ == "git.file") then
+      producer = snap.get("producer.git.file")
+    else
+      local function _4_()
+        local p = _3_
+        return (type(p) == "function")
+      end
+      if ((nil ~= _3_) and _4_()) then
+        local p = _3_
+        producer = p
+      else
+        local _ = _3_
+        producer = assert(false, "file.producer is invalid")
+      end
+    end
+  end
+  if ((type == "ripgrep.file") or (type == "fd.file")) then
+    if config.args then
+      producer = producer.args(config.args)
+    elseif config.hidden then
+      producer = producer.hidden
+    end
+  end
+  return producer
+end
+local function file_prompt_by_type(type)
+  local _3_ = type
+  if (_3_ == "ripgrep.file") then
+    return "Rg Files"
+  elseif (_3_ == "vim.oldfile") then
+    return "Old Files"
+  elseif (_3_ == "vim.buffer") then
+    return "Buffers"
+  elseif (_3_ == "git.file") then
+    return "Git Files"
+  else
+    local _ = _3_
+    return "Custom Files"
+  end
 end
 local file
 do
   local v_0_
   do
     local v_0_0
-    local function file0(config)
-      assert((type(config) == "table"))
-      if config.prompt then
-        assert((type(config.prompt) == "string"), "file.prompt must be a string")
-      end
-      if config.layout then
-        assert((type(config.layout) == "function"), "file.layout must be a function")
-      end
-      if config.args then
-        assert((type(config.args) == "table"), "file.args must be a table")
-      end
-      if config.hidden then
-        assert((type(config.hidden) == "boolean"), "file.hidden must be a boolean")
-      end
-      local producer_type = (config.producer or "ripgrep.file")
-      local consumer_type = (config.consumer or "fzf")
-      local producer
-      do
-        local _7_ = producer_type
-        if (_7_ == "ripgrep.file") then
-          producer = snap.get("producer.ripgrep.file")
-        elseif (_7_ == "vim.oldfile") then
-          producer = snap.get("producer.vim.oldfile")
-        elseif (_7_ == "vim.buffer") then
-          producer = snap.get("producer.vim.buffer")
-        elseif (_7_ == "git.file") then
-          producer = snap.get("producer.git.file")
-        else
-          local function _8_()
-            local p = _7_
-            return (type(p) == "function")
-          end
-          if ((nil ~= _7_) and _8_()) then
-            local p = _7_
-            producer = p
-          else
-            local _ = _7_
-            producer = assert(false, "file.producer is invalid")
-          end
+    local function _3_(self_0_, ...)
+      local function _4_(config)
+        assert((type(config) == "table"))
+        if config.prompt then
+          assert((type(config.prompt) == "string"), "file.prompt must be a string")
         end
-      end
-      if (producer_type == "ripgrep.file") then
+        if config.layout then
+          assert((type(config.layout) == "function"), "file.layout must be a function")
+        end
         if config.args then
-          producer = producer.args(config.args)
-        elseif config.hidden then
-          producer = producer.hidden
+          assert((type(config.args) == "table"), "file.args must be a table")
         end
-      end
-      local consumer
-      do
-        local _9_ = consumer_type
-        if (_9_ == "fzf") then
-          consumer = snap.get("consumer.fzf")
-        elseif (_9_ == "fzy") then
-          consumer = snap.get("consumer.fzy")
+        if config.hidden then
+          assert((type(config.hidden) == "boolean"), "file.hidden must be a boolean")
+        end
+        if config.try then
+          assert((type(config.try) == "table"), "file.try must be a table")
+        end
+        if config.combine then
+          assert((type(config.combine) == "table"), "file.combine must be a table")
+        end
+        assert((config.producer or config.try or config.combine), "one of file.producer, file.try or file.combine must be set")
+        assert(not (config.producer and config.try), "file.try and file.producer can not be used together")
+        assert(not (config.producer and config.combine), "file.combine and file.producer can not be used together")
+        assert(not (config.try and config.combine), "file.try and file.combine can not be used together")
+        assert(not (config.hidden and config.args), "file.args and file.hidden can not be used together")
+        local by_type
+        local function _11_(...)
+          return file_producer_by_type(config, ...)
+        end
+        by_type = _11_
+        local consumer_type = (config.consumer or "fzf")
+        local producer
+        if config.try then
+          producer = snap.get("consumer.try")(unpack(vim.tbl_map(by_type, config.try)))
+        elseif config.combine then
+          producer = snap.get("consumer.combine")(unpack(vim.tbl_map(by_type, config.combine)))
         else
-          local function _10_()
-            local c = _9_
-            return (type(c) == "function")
-          end
-          if ((nil ~= _9_) and _10_()) then
-            local c = _9_
-            consumer = c
+          producer = by_type(config.producer)
+        end
+        local consumer
+        do
+          local _13_ = consumer_type
+          if (_13_ == "fzf") then
+            consumer = snap.get("consumer.fzf")
+          elseif (_13_ == "fzy") then
+            consumer = snap.get("consumer.fzy")
           else
-            local _ = _9_
-            consumer = assert(false, "file.consumer is invalid")
+            local function _14_()
+              local c = _13_
+              return (type(c) == "function")
+            end
+            if ((nil ~= _13_) and _14_()) then
+              local c = _13_
+              consumer = c
+            else
+              local _ = _13_
+              consumer = assert(false, "file.consumer is invalid")
+            end
           end
         end
-      end
-      local prompt
-      local function _11_()
-        local _10_ = producer_type
-        if (_10_ == "ripgrep.file") then
-          return "Files>"
-        elseif (_10_ == "vim.oldfile") then
-          return "Old Files>"
-        elseif (_10_ == "vim.buffer") then
-          return "Buffers>"
-        elseif (_10_ == "git.file") then
-          return "Git Files>"
-        else
-          local _ = _10_
-          return "Files>"
+        local create_prompt0
+        local function _14_(...)
+          return create_prompt(config.prefix, ...)
         end
+        create_prompt0 = _14_
+        local prompt
+        if config.prompt then
+          prompt = create_prompt0(config.prompt)
+        elseif config.producer then
+          prompt = create_prompt0(file_prompt_by_type(config.producer))
+        elseif config.try then
+          prompt = create_prompt0(table.concat(vim.tbl_map(file_prompt_by_type, config.try), " or "))
+        elseif config.combine then
+          prompt = create_prompt0(table.concat(vim.tbl_map(file_prompt_by_type, config.combine), " + "))
+        else
+        prompt = nil
+        end
+        local select = snap.get("select.file")
+        local function _16_()
+          return snap.run({layout = (config.layout or nil), multiselect = select.multiselect, producer = consumer(producer), prompt = prompt, reverse = (config.reverse or false), select = select.select, views = {snap.get("preview.file")}})
+        end
+        return _16_
       end
-      prompt = (config.prompt or _11_())
-      local select = snap.get("select.file")
-      local function _12_()
-        return snap.run({layout = (config.layout or nil), multiselect = select.multiselect, producer = consumer(producer), prompt = prompt, reverse = (config.reverse or false), select = select.select, views = {snap.get("preview.file")}})
-      end
-      return _12_
+      return _4_(...)
     end
-    v_0_0 = file0
-    _0_["file"] = v_0_0
+    v_0_0 = setmetatable({with = with}, {__call = _3_})
+    do end (_0_)["file"] = v_0_0
     v_0_ = v_0_0
   end
   local t_0_ = (_0_)["aniseed/locals"]
   t_0_["file"] = v_0_
   file = v_0_
 end
+local function vimgrep_prompt_by_type(type)
+  local _3_ = type
+  if (_3_ == "ripgrep.vimgrep") then
+    return "Rg Vimgrep"
+  else
+    local _ = _3_
+    return "Custom Vimgrep"
+  end
+end
 local vimgrep
 do
   local v_0_
   do
     local v_0_0
-    local function vimgrep0(config)
-      assert((type(config) == "table"))
-      if config.prompt then
-        assert((type(config.prompt) == "string"), "vimgrep.prompt must be a string")
-      end
-      if config.limit then
-        assert((type(config.limit) == "number"), "vimgrep.limit must be a number")
-      end
-      if config.layout then
-        assert((type(config.layout) == "function"), "vimgrep.layout must be a function")
-      end
-      if config.args then
-        assert((type(config.args) == "table"), "vimgrep.args must be a table")
-      end
-      if config.hidden then
-        assert((type(config.hidden) == "boolean"), "vimgrep.hidden must be a boolean")
-      end
-      local producer_type = (config.producer or "ripgrep.vimgrep")
-      local producer
-      do
-        local _8_ = producer_type
-        if (_8_ == "ripgrep.vimgrep") then
-          producer = snap.get("producer.ripgrep.vimgrep")
-        else
-          local function _9_()
-            local p = _8_
-            return (type(p) == "function")
-          end
-          if ((nil ~= _8_) and _9_()) then
-            local p = _8_
-            producer = p
-          else
-            local _ = _8_
-            producer = assert(false, "vimgrep.producer is invalid")
-          end
+    local function _3_(self_0_, ...)
+      local function _4_(config)
+        assert((type(config) == "table"))
+        if config.prompt then
+          assert((type(config.prompt) == "string"), "vimgrep.prompt must be a string")
         end
-      end
-      if (producer_type == "ripgrep.vimgrep") then
+        if config.limit then
+          assert((type(config.limit) == "number"), "vimgrep.limit must be a number")
+        end
+        if config.layout then
+          assert((type(config.layout) == "function"), "vimgrep.layout must be a function")
+        end
         if config.args then
-          producer = producer.args(config.args)
-        elseif config.hidden then
-          producer = producer.hidden
+          assert((type(config.args) == "table"), "vimgrep.args must be a table")
         end
-      end
-      local consumer
-      if config.limit then
-        local function _10_(...)
-          return snap.get("consumer.limit")(config.limit, ...)
+        if config.hidden then
+          assert((type(config.hidden) == "boolean"), "vimgrep.hidden must be a boolean")
         end
-        consumer = _10_
-      else
-        local function _10_(producer0)
-          return producer0
+        local producer_type = (config.producer or "ripgrep.vimgrep")
+        local producer
+        do
+          local _10_ = producer_type
+          if (_10_ == "ripgrep.vimgrep") then
+            producer = snap.get("producer.ripgrep.vimgrep")
+          else
+            local function _11_()
+              local p = _10_
+              return (type(p) == "function")
+            end
+            if ((nil ~= _10_) and _11_()) then
+              local p = _10_
+              producer = p
+            else
+              local _ = _10_
+              producer = assert(false, "vimgrep.producer is invalid")
+            end
+          end
         end
-        consumer = _10_
+        if (producer_type == "ripgrep.vimgrep") then
+          if config.args then
+            producer = producer.args(config.args)
+          elseif config.hidden then
+            producer = producer.hidden
+          end
+        end
+        local consumer
+        if config.limit then
+          local function _12_(...)
+            return snap.get("consumer.limit")(config.limit, ...)
+          end
+          consumer = _12_
+        else
+          local function _12_(producer0)
+            return producer0
+          end
+          consumer = _12_
+        end
+        local create_prompt0
+        local function _13_(...)
+          return create_prompt(config.prefix, ...)
+        end
+        create_prompt0 = _13_
+        local prompt
+        if config.prompt then
+          prompt = create_prompt0(config.prompt)
+        elseif producer_type then
+          prompt = create_prompt0(vimgrep_prompt_by_type(producer_type))
+        else
+        prompt = nil
+        end
+        local select = snap.get("select.vimgrep")
+        local function _15_()
+          return snap.run({layout = (config.layout or nil), multiselect = select.multiselect, producer = consumer(producer), prompt = prompt, select = select.select, views = {snap.get("preview.vimgrep")}})
+        end
+        return _15_
       end
-      local select = snap.get("select.vimgrep")
-      local function _11_()
-        return snap.run({layout = (config.layout or nil), multiselect = select.multiselect, producer = consumer(producer), prompt = (config.prompt or "Grep>"), select = select.select, views = {snap.get("preview.vimgrep")}})
-      end
-      return _11_
+      return _4_(...)
     end
-    v_0_0 = vimgrep0
-    _0_["vimgrep"] = v_0_0
+    v_0_0 = setmetatable({with = with}, {__call = _3_})
+    do end (_0_)["vimgrep"] = v_0_0
     v_0_ = v_0_0
   end
   local t_0_ = (_0_)["aniseed/locals"]

--- a/lua/snap/init.lua
+++ b/lua/snap/init.lua
@@ -60,6 +60,30 @@ do
   t_0_["register"] = v_0_
   register0 = v_0_
 end
+local map
+do
+  local v_0_
+  do
+    local v_0_0
+    local function map0(key, fnc, command)
+      assert((type(key) == "string"), "map key argument must be a string")
+      assert((type(fnc) == "function"), "map fnc argument must be a function")
+      if command then
+        assert((type(command) == "string"), "map command argument must be a string")
+      end
+      register0.map("n", key, fnc)
+      if command then
+        return register0.command(command, fnc)
+      end
+    end
+    v_0_0 = map0
+    _0_["map"] = v_0_0
+    v_0_ = v_0_0
+  end
+  local t_0_ = (_0_)["aniseed/locals"]
+  t_0_["map"] = v_0_
+  map = v_0_
+end
 local get_producer
 do
   local v_0_

--- a/lua/snap/init.lua
+++ b/lua/snap/init.lua
@@ -65,15 +65,15 @@ do
   local v_0_
   do
     local v_0_0
-    local function map0(key, fnc, command)
+    local function map0(key, run, command)
       assert((type(key) == "string"), "map key argument must be a string")
-      assert((type(fnc) == "function"), "map fnc argument must be a function")
+      assert((type(run) == "function"), "map run argument must be a function")
       if command then
         assert((type(command) == "string"), "map command argument must be a string")
       end
-      register0.map("n", key, fnc)
+      register0.map("n", key, run)
       if command then
-        return register0.command(command, fnc)
+        return register0.command(command, run)
       end
     end
     v_0_0 = map0
@@ -83,6 +83,29 @@ do
   local t_0_ = (_0_)["aniseed/locals"]
   t_0_["map"] = v_0_
   map = v_0_
+end
+local maps
+do
+  local v_0_
+  do
+    local v_0_0
+    local function maps0(config)
+      for _, _3_ in ipairs(config) do
+        local _each_0_ = _3_
+        local key = _each_0_[1]
+        local run = _each_0_[2]
+        local command = _each_0_[3]
+        map(key, run, command)
+      end
+      return nil
+    end
+    v_0_0 = maps0
+    _0_["maps"] = v_0_0
+    v_0_ = v_0_0
+  end
+  local t_0_ = (_0_)["aniseed/locals"]
+  t_0_["maps"] = v_0_
+  maps = v_0_
 end
 local get_producer
 do

--- a/lua/snap/init.lua
+++ b/lua/snap/init.lua
@@ -25,11 +25,11 @@ autoload = _1_
 local function _2_(...)
   local ok_3f_0_, val_0_ = nil, nil
   local function _2_()
-    return {require("snap.common.buffer"), require("snap.producer.create"), require("snap.view.input"), require("snap.common.register"), require("snap.producer.request"), require("snap.view.results"), require("snap.common.tbl"), require("snap.view.view"), require("snap.common.window")}
+    return {require("snap.common.buffer"), require("snap.config"), require("snap.producer.create"), require("snap.view.input"), require("snap.common.register"), require("snap.producer.request"), require("snap.view.results"), require("snap.common.tbl"), require("snap.view.view"), require("snap.common.window")}
   end
   ok_3f_0_, val_0_ = pcall(_2_)
   if ok_3f_0_ then
-    _0_["aniseed/local-fns"] = {["require-macros"] = {["snap.macros"] = true}, require = {buffer = "snap.common.buffer", create = "snap.producer.create", input = "snap.view.input", register = "snap.common.register", request = "snap.producer.request", results = "snap.view.results", tbl = "snap.common.tbl", view = "snap.view.view", window = "snap.common.window"}}
+    _0_["aniseed/local-fns"] = {["require-macros"] = {["snap.macros"] = true}, require = {buffer = "snap.common.buffer", config = "snap.config", create = "snap.producer.create", input = "snap.view.input", register = "snap.common.register", request = "snap.producer.request", results = "snap.view.results", tbl = "snap.common.tbl", view = "snap.view.view", window = "snap.common.window"}}
     return val_0_
   else
     return print(val_0_)
@@ -37,14 +37,15 @@ local function _2_(...)
 end
 local _local_0_ = _2_(...)
 local buffer = _local_0_[1]
-local create = _local_0_[2]
-local input = _local_0_[3]
-local register = _local_0_[4]
-local request = _local_0_[5]
-local results = _local_0_[6]
-local tbl = _local_0_[7]
-local view = _local_0_[8]
-local window = _local_0_[9]
+local window = _local_0_[10]
+local config = _local_0_[2]
+local create = _local_0_[3]
+local input = _local_0_[4]
+local register = _local_0_[5]
+local request = _local_0_[6]
+local results = _local_0_[7]
+local tbl = _local_0_[8]
+local view = _local_0_[9]
 local _2amodule_2a = _0_
 local _2amodule_name_2a = "snap"
 do local _ = ({nil, _0_, nil, {{nil}, nil, nil, nil}})[2] end
@@ -59,6 +60,18 @@ do
   local t_0_ = (_0_)["aniseed/locals"]
   t_0_["register"] = v_0_
   register0 = v_0_
+end
+local config0
+do
+  local v_0_
+  do
+    local v_0_0 = config
+    _0_["config"] = v_0_0
+    v_0_ = v_0_0
+  end
+  local t_0_ = (_0_)["aniseed/locals"]
+  t_0_["config"] = v_0_
+  config0 = v_0_
 end
 local map
 do
@@ -89,8 +102,8 @@ do
   local v_0_
   do
     local v_0_0
-    local function maps0(config)
-      for _, _3_ in ipairs(config) do
+    local function maps0(config1)
+      for _, _3_ in ipairs(config1) do
         local _each_0_ = _3_
         local key = _each_0_[1]
         local run = _each_0_[2]
@@ -350,45 +363,62 @@ do
   local v_0_
   do
     local v_0_0
-    local function run0(config)
-      assert((type(config) == "table"), "snap.run config must be a table")
-      assert((type(get_producer(config.producer)) == "function"), "snap.run 'producer' must be a function or a table with a default function")
-      assert((type(config.select) == "function"), "snap.run 'select' must be a function")
-      if config.multiselect then
-        assert((type(config.multiselect) == "function"), "snap.run 'multiselect' must be a function")
+    local function run0(config1)
+      assert((type(config1) == "table"), "snap.run config must be a table")
+      assert((type(get_producer(config1.producer)) == "function"), "snap.run 'producer' must be a function or a table with a default function")
+      assert((type(config1.select) == "function"), "snap.run 'select' must be a function")
+      if config1.multiselect then
+        assert((type(config1.multiselect) == "function"), "snap.run 'multiselect' must be a function")
       end
-      if config.prompt then
-        assert((type(config.prompt) == "string"), "snap.run 'prompt' must be a string")
+      if config1.prompt then
+        assert((type(config1.prompt) == "string"), "snap.run 'prompt' must be a string")
       end
-      if config.layout then
-        assert((type(config.layout) == "function"), "snap.run 'layout' must be a function")
+      if config1.layout then
+        assert((type(config1.layout) == "function"), "snap.run 'layout' must be a function")
       end
-      if config.views then
-        assert((type(config.views) == "table"), "snap.run 'views' must be a table")
+      if config1["hide-views"] then
+        assert(vim.tbl_contains({"boolean", "function"}, type(config1["hide-views"])), "snap.run 'hide-views' must be a boolean or a function")
       end
-      if config.views then
-        for _, view0 in ipairs(config.views) do
+      if config1.views then
+        assert((type(config1.views) == "table"), "snap.run 'views' must be a table")
+      end
+      if config1.views then
+        for _, view0 in ipairs(config1.views) do
           assert((type(view0) == "function"), "snap.run each view in 'views' must be a function")
         end
       end
-      if config.loading then
-        assert((type(config.loading) == "function"), "snap.run 'loading' must be a function")
+      if config1.loading then
+        assert((type(config1.loading) == "function"), "snap.run 'loading' must be a function")
       end
-      if config.reverse then
-        assert((type(config.reverse) == "boolean"), "snap.run 'reverse' must be a boolean")
+      if config1.reverse then
+        assert((type(config1.reverse) == "boolean"), "snap.run 'reverse' must be a boolean")
       end
       local last_results = {}
       local last_requested_filter = ""
       local last_requested_selection = nil
       local exit = false
-      local layout = (config.layout or (get("layout")).centered)
-      local loading = (config.loading or get("loading"))
-      local initial_filter = (config.initial_filter or "")
+      local layout = (config1.layout or (get("layout")).centered)
+      local loading = (config1.loading or get("loading"))
+      local initial_filter = (config1.initial_filter or "")
       local original_winnr = vim.api.nvim_get_current_win()
-      local prompt = string.format("%s ", (config.prompt or "Find>"))
+      local prompt = string.format("%s ", (config1.prompt or "Find>"))
       local selected = {}
       local cursor_row = 1
-      local hide_views = false
+      local hide_views = nil
+      local function get_hide_views()
+        if (hide_views ~= nil) then
+          return hide_views
+        elseif (config1["hide-views"] ~= nil) then
+          local _11_ = type(config1["hide-views"])
+          if (_11_ == "function") then
+            return config1["hide-views"]()
+          elseif (_11_ == "boolean") then
+            return config1["hide-views"]
+          end
+        else
+          return false
+        end
+      end
       local input_view = nil
       local results_view = nil
       local views = {}
@@ -399,10 +429,10 @@ do
         exit = true
         last_results = {}
         selected = nil
-        config["producer"] = nil
-        config["views"] = nil
-        for _, _10_ in ipairs(views) do
-          local _each_0_ = _10_
+        config1["producer"] = nil
+        config1["views"] = nil
+        for _, _11_ in ipairs(views) do
+          local _each_0_ = _11_
           local view0 = _each_0_["view"]
           view0:delete()
         end
@@ -412,17 +442,17 @@ do
         return vim.api.nvim_command("stopinsert")
       end
       local total_views
-      if config.views then
-        total_views = #config.views
+      if config1.views then
+        total_views = #config1.views
       else
         total_views = 0
       end
       local function has_views()
-        return (not hide_views and (total_views > 0))
+        return ((total_views > 0) and not get_hide_views())
       end
       local function create_views()
         if has_views() then
-          for index, producer in ipairs(config.views) do
+          for index, producer in ipairs(config1.views) do
             local view0 = {producer = producer, view = view.create({["total-views"] = total_views, index = index, layout = layout})}
             table.insert(views, view0)
           end
@@ -430,25 +460,16 @@ do
         end
       end
       create_views()
-      results_view = results.create({["has-views"] = has_views, layout = layout})
-      local partial_results_length = 1
+      results_view = results.create({["has-views"] = has_views, layout = layout, reverse = config1.reverse})
       local function update_cursor()
-        if config.reverse then
-          vim.api.nvim_win_set_cursor(results_view.winnr, {(partial_results_length - (cursor_row - 1)), 0})
-          local function _11_(...)
-            return vim.api.nvim_command("silent normal zb", ...)
-          end
-          return vim.api.nvim_win_call(results_view.winnr, _11_)
-        else
-          return vim.api.nvim_win_set_cursor(results_view.winnr, {cursor_row, 0})
-        end
+        return vim.api.nvim_win_set_cursor(results_view.winnr, {cursor_row, 0})
       end
       local update_views
       do
         local body_0_
-        local function _11_(selection)
-          for _, _12_ in ipairs(views) do
-            local _each_0_ = _12_
+        local function _12_(selection)
+          for _, _13_ in ipairs(views) do
+            local _each_0_ = _13_
             local producer = _each_0_["producer"]
             local _each_1_ = _each_0_["view"]
             local bufnr = _each_1_["bufnr"]
@@ -464,28 +485,28 @@ do
           end
           return nil
         end
-        body_0_ = _11_
+        body_0_ = _12_
         local args_0_ = nil
-        local function _12_(...)
+        local function _13_(...)
           if (args_0_ == nil) then
             args_0_ = {...}
-            local function _13_()
+            local function _14_()
               local actual_args_0_ = args_0_
               args_0_ = nil
               return body_0_(unpack(actual_args_0_))
             end
-            return vim.schedule(_13_)
+            return vim.schedule(_14_)
           else
             args_0_ = {...}
             return nil
           end
         end
-        update_views = _12_
+        update_views = _13_
       end
       local write_results
       do
         local body_0_
-        local function _11_(results0, force_views)
+        local function _12_(results0, force_views)
           if not exit then
             do
               local result_size = #results0
@@ -494,7 +515,6 @@ do
               end
               if (result_size == 0) then
                 buffer["set-lines"](results_view.bufnr, 0, -1, {})
-                partial_results_length = 1
                 update_cursor()
               else
                 local max = (results_view.height + cursor_row)
@@ -503,48 +523,26 @@ do
                   if (max == #partial_results) then break end
                   table.insert(partial_results, tostring(result))
                 end
-                partial_results_length = #partial_results
-                if config.reverse then
-                  if (partial_results_length < results_view.height) then
-                    for _ = partial_results_length, results_view.height do
-                      table.insert(partial_results, "")
-                    end
-                  end
-                  partial_results_length = #partial_results
-                  for left_index = 1, math.floor((partial_results_length / 2)) do
-                    local left = partial_results[left_index]
-                    local right_index = (partial_results_length - (left_index - 1))
-                    local right = partial_results[right_index]
-                    partial_results[left_index] = right
-                    partial_results[right_index] = left
-                  end
-                end
                 buffer["set-lines"](results_view.bufnr, 0, -1, partial_results)
                 update_cursor()
                 for row in pairs(partial_results) do
                   local result = (results0)[row]
-                  local reverse_handled_row
-                  if config.reverse then
-                    reverse_handled_row = (partial_results_length - (row - 1))
-                  else
-                    reverse_handled_row = row
-                  end
                   if has_meta(result, "positions") then
-                    local function _16_()
-                      local _15_ = type(result.positions)
-                      if (_15_ == "table") then
+                    local function _15_()
+                      local _14_ = type(result.positions)
+                      if (_14_ == "table") then
                         return result.positions
-                      elseif (_15_ == "function") then
+                      elseif (_14_ == "function") then
                         return result:positions()
                       else
-                        local _ = _15_
+                        local _ = _14_
                         return assert(false, "result positions must be a table or function")
                       end
                     end
-                    buffer["add-positions-highlight"](results_view.bufnr, reverse_handled_row, _16_())
+                    buffer["add-positions-highlight"](results_view.bufnr, row, _15_())
                   end
                   if selected[tostring(result)] then
-                    buffer["add-selected-highlight"](results_view.bufnr, reverse_handled_row)
+                    buffer["add-selected-highlight"](results_view.bufnr, row)
                   end
                 end
               end
@@ -552,8 +550,8 @@ do
             local selection = get_selection()
             if (has_views() and (force_views or (tostring(last_requested_selection) ~= tostring(selection)))) then
               last_requested_selection = selection
-              for _, _12_ in ipairs(views) do
-                local _each_0_ = _12_
+              for _, _13_ in ipairs(views) do
+                local _each_0_ = _13_
                 local view0 = _each_0_["view"]
                 local bufnr = buffer.create()
                 vim.api.nvim_win_set_buf(view0.winnr, bufnr)
@@ -566,23 +564,23 @@ do
             end
           end
         end
-        body_0_ = _11_
+        body_0_ = _12_
         local args_0_ = nil
-        local function _12_(...)
+        local function _13_(...)
           if (args_0_ == nil) then
             args_0_ = {...}
-            local function _13_()
+            local function _14_()
               local actual_args_0_ = args_0_
               args_0_ = nil
               return body_0_(unpack(actual_args_0_))
             end
-            return vim.schedule(_13_)
+            return vim.schedule(_14_)
           else
             args_0_ = {...}
             return nil
           end
         end
-        write_results = _12_
+        write_results = _13_
       end
       local function on_update(filter)
         last_requested_filter = filter
@@ -596,50 +594,50 @@ do
         end
         local body = {filter = filter, height = results_view.height, winnr = original_winnr}
         local request0 = request.create({body = body, cancel = cancel})
-        local config0 = {producer = get_producer(config.producer), request = request0}
+        local config2 = {producer = get_producer(config1.producer), request = request0}
         local write_loading
         do
           local body_0_
-          local function _11_()
+          local function _12_()
             if not request0.canceled() then
               local loading_screen = loading(results_view.width, results_view.height, loading_count)
               return buffer["set-lines"](results_view.bufnr, 0, -1, loading_screen)
             end
           end
-          body_0_ = _11_
+          body_0_ = _12_
           local args_0_ = nil
-          local function _12_(...)
+          local function _13_(...)
             if (args_0_ == nil) then
               args_0_ = {...}
-              local function _13_()
+              local function _14_()
                 local actual_args_0_ = args_0_
                 args_0_ = nil
                 return body_0_(unpack(actual_args_0_))
               end
-              return vim.schedule(_13_)
+              return vim.schedule(_14_)
             else
               args_0_ = {...}
               return nil
             end
           end
-          write_loading = _12_
+          write_loading = _13_
         end
-        config0["on-end"] = function()
+        config2["on-end"] = function()
           if (#results0 == 0) then
             last_results = results0
             write_results(last_results)
           elseif has_meta(tbl.first(results0), "score") then
-            local function _11_(_241, _242)
+            local function _12_(_241, _242)
               return (_241.score > _242.score)
             end
-            tbl["partial-quicksort"](results0, 1, #results0, (results_view.height + cursor_row), _11_)
+            tbl["partial-quicksort"](results0, 1, #results0, (results_view.height + cursor_row), _12_)
             last_results = results0
             write_results(last_results)
           end
           results0 = {}
           return nil
         end
-        config0["on-tick"] = function()
+        config2["on-tick"] = function()
           if not early_write then
             local current_time = vim.loop.now()
             if (((loading_count == 0) and ((current_time - first_time) > 100)) or ((current_time - last_time) > 500)) then
@@ -649,7 +647,7 @@ do
             end
           end
         end
-        config0["on-value"] = function(value)
+        config2["on-value"] = function(value)
           assert((type(value) == "table"), "Main producer yielded a non-yieldable value")
           if (#value > 0) then
             tbl.accumulate(results0, value)
@@ -660,21 +658,21 @@ do
             end
           end
         end
-        return create(config0)
+        return create(config2)
       end
       local function on_enter(type)
         local selections = vim.tbl_keys(selected)
         if (#selections == 0) then
           local selection = get_selection()
           if (selection ~= nil) then
-            return vim.schedule_wrap(config.select)(selection, original_winnr, type)
+            return vim.schedule_wrap(config1.select)(selection, original_winnr, type)
           end
-        elseif config.multiselect then
-          return vim.schedule_wrap(config.multiselect)(selections, original_winnr)
+        elseif config1.multiselect then
+          return vim.schedule_wrap(config1.multiselect)(selections, original_winnr)
         end
       end
       local function on_select_all_toggle()
-        if config.multiselect then
+        if config1.multiselect then
           for _, value in ipairs(last_results) do
             local value0 = tostring(value)
             if selected[value0] then
@@ -687,7 +685,7 @@ do
         end
       end
       local function on_select_toggle()
-        if config.multiselect then
+        if config1.multiselect then
           local selection = get_selection()
           if (selection ~= nil) then
             local value = tostring(selection)
@@ -709,28 +707,28 @@ do
         return write_results(last_results)
       end
       local function on_prev_item()
-        local function _11_(_241)
+        local function _12_(_241)
           return (_241 - 1)
         end
-        return on_key_direction(_11_)
+        return on_key_direction(_12_)
       end
       local function on_next_item()
-        local function _11_(_241)
+        local function _12_(_241)
           return (_241 + 1)
         end
-        return on_key_direction(_11_)
+        return on_key_direction(_12_)
       end
       local function on_prev_page()
-        local function _11_(_241)
+        local function _12_(_241)
           return (_241 - results_view.height)
         end
-        return on_key_direction(_11_)
+        return on_key_direction(_12_)
       end
       local function on_next_page()
-        local function _11_(_241)
+        local function _12_(_241)
           return (_241 + results_view.height)
         end
-        return on_key_direction(_11_)
+        return on_key_direction(_12_)
       end
       local function set_next_view_row(next_index)
         if has_views() then
@@ -748,64 +746,68 @@ do
       end
       local function on_viewpageup()
         if has_views() then
-          local function _11_(_241, _242)
+          local function _12_(_241, _242)
             return (_241 - _242)
           end
-          return set_next_view_row(_11_)
+          return set_next_view_row(_12_)
         end
       end
       local function on_viewpagedown()
         if has_views() then
-          local function _11_(_241, _242)
+          local function _12_(_241, _242)
             return (_241 + _242)
           end
-          return set_next_view_row(_11_)
+          return set_next_view_row(_12_)
         end
       end
       local function on_next()
-        if (config.next or (config.steps and (#config.steps > 0))) then
+        if (config1.next or (config1.steps and (#config1.steps > 0))) then
           local results0 = last_results
           local next_config = {}
-          for key, value in pairs(config) do
+          for key, value in pairs(config1) do
             next_config[key] = value
           end
-          local next = (config.next or table.remove(config.steps))
-          local function _11_()
+          local next = (config1.next or table.remove(config1.steps))
+          local function _12_()
             do
-              local _12_ = type(next)
-              if (_12_ == "function") then
-                local function _13_()
+              local _13_ = type(next)
+              if (_13_ == "function") then
+                local function _14_()
                   return results0
                 end
-                next_config["producer"] = next(_13_)
-              elseif (_12_ == "table") then
+                next_config["producer"] = next(_14_)
+              elseif (_13_ == "table") then
                 for key, value in pairs(next.config) do
                   next_config[key] = value
                 end
-                local _13_
+                local _14_
                 if next.format then
-                  _13_ = next.consumer(next.format(results0))
+                  _14_ = next.consumer(next.format(results0))
                 else
-                  local function _14_()
+                  local function _15_()
                     return results0
                   end
-                  _13_ = next.consumer(_14_)
+                  _14_ = next.consumer(_15_)
                 end
-                next_config["producer"] = _13_
+                next_config["producer"] = _14_
               end
             end
             return run0(next_config)
           end
-          return vim.schedule_wrap(_11_)()
+          return vim.schedule_wrap(_12_)()
         end
       end
       local function on_view_toggle_hide()
-        hide_views = not hide_views
+        if (hide_views == nil) then
+          hide_views = not get_hide_views()
+        else
+          hide_views = not hide_views
+        end
         results_view:update()
         input_view:update()
         if hide_views then
-          for _, _11_ in ipairs(views) do
-            local _each_0_ = _11_
+          for _, _13_ in ipairs(views) do
+            local _each_0_ = _13_
             local view0 = _each_0_["view"]
             view0:delete()
           end
@@ -817,7 +819,7 @@ do
           return write_results(last_results, true)
         end
       end
-      input_view = input.create({["has-views"] = has_views, ["on-enter"] = on_enter, ["on-exit"] = on_exit, ["on-next"] = on_next, ["on-next-item"] = on_next_item, ["on-next-page"] = on_next_page, ["on-prev-item"] = on_prev_item, ["on-prev-page"] = on_prev_page, ["on-select-all-toggle"] = on_select_all_toggle, ["on-select-toggle"] = on_select_toggle, ["on-update"] = on_update, ["on-view-toggle-hide"] = on_view_toggle_hide, ["on-viewpagedown"] = on_viewpagedown, ["on-viewpageup"] = on_viewpageup, layout = layout, mappings = config.mappings, prompt = prompt, reverse = config.reverse})
+      input_view = input.create({["has-views"] = has_views, ["on-enter"] = on_enter, ["on-exit"] = on_exit, ["on-next"] = on_next, ["on-next-item"] = on_next_item, ["on-next-page"] = on_next_page, ["on-prev-item"] = on_prev_item, ["on-prev-page"] = on_prev_page, ["on-select-all-toggle"] = on_select_all_toggle, ["on-select-toggle"] = on_select_toggle, ["on-update"] = on_update, ["on-view-toggle-hide"] = on_view_toggle_hide, ["on-viewpagedown"] = on_viewpagedown, ["on-viewpageup"] = on_viewpageup, layout = layout, mappings = config1.mappings, prompt = prompt, reverse = config1.reverse})
       if (initial_filter ~= "") then
         vim.api.nvim_feedkeys(initial_filter, "n", false)
       end
@@ -836,10 +838,10 @@ do
   local v_0_
   do
     local v_0_0
-    local function create1(config, defaults)
-      assert((type(config) == "function"), "Config must be a function")
+    local function create1(config1, defaults)
+      assert((type(config1) == "function"), "Config must be a function")
       local function _3_()
-        return run(tbl.merge((defaults or {}), config()))
+        return run(tbl.merge((defaults or {}), config1()))
       end
       return _3_
     end

--- a/lua/snap/layout/init.lua
+++ b/lua/snap/layout/init.lua
@@ -133,7 +133,12 @@ do
   do
     local v_0_0
     local function bottom0()
-      return _25bottom(0.9, 0.7)
+      local lines0 = vim.api.nvim_get_option("lines")
+      local height = math.floor((lines0 * 0.5))
+      local width = (vim.api.nvim_get_option("columns") - 4)
+      local col = 0
+      local row = (lines0 - height - 4)
+      return {col = col, height = height, row = row, width = width}
     end
     v_0_0 = bottom0
     _0_["bottom"] = v_0_0

--- a/lua/snap/layout/init.lua
+++ b/lua/snap/layout/init.lua
@@ -135,7 +135,7 @@ do
     local function bottom0()
       local lines0 = vim.api.nvim_get_option("lines")
       local height = math.floor((lines0 * 0.5))
-      local width = (vim.api.nvim_get_option("columns") - 4)
+      local width = vim.api.nvim_get_option("columns")
       local col = 0
       local row = (lines0 - height - 4)
       return {col = col, height = height, row = row, width = width}

--- a/lua/snap/macros.fnl
+++ b/lua/snap/macros.fnl
@@ -2,6 +2,10 @@
 (fn safefn [name ...]
   `(local ,name (vim.schedule_wrap (fn ,...))))
 
+;; Defines a metafunction
+(fn defmetafn [name tbl ...]
+  `(def ,name (setmetatable ,tbl {:__call (fn [self# ...] ((fn ,...) ...))})))
+
 ;; Calls a non-fast mode function safely
 (fn safecall [fnc ...]
   `((vim.schedule_wrap ,fnc) ,...))
@@ -77,6 +81,7 @@
 {: safefn
  : safecall
  : safedebounced
+ : defmetafn
  : asserttype
  : asserttype?
  : assertfunction

--- a/lua/snap/macros.fnl
+++ b/lua/snap/macros.fnl
@@ -33,6 +33,12 @@
            ;; so just swap the args to be called with
            (set args# [...]))))))
 
+(fn asserttypes [types value msg]
+  `(assert (vim.tbl_contains ,types (type ,value)) ,msg))
+
+(fn asserttypes? [types value msg]
+  `(when ,value (asserttypes ,types ,value ,msg)))
+
 (fn asserttype [typ value msg]
   `(assert (= (type ,value) ,typ) ,msg))
 
@@ -82,6 +88,8 @@
  : safecall
  : safedebounced
  : defmetafn
+ : asserttypes
+ : asserttypes?
  : asserttype
  : asserttype?
  : assertfunction

--- a/lua/snap/macros.fnl
+++ b/lua/snap/macros.fnl
@@ -65,6 +65,12 @@
 (fn assertboolean? [value msg]
   `(asserttype? :boolean ,value ,msg))
 
+(fn assertnumber [value msg]
+  `(asserttype :number ,value ,msg))
+
+(fn assertnumber? [value msg]
+  `(asserttype? :number ,value ,msg))
+
 (fn assertmetatable [value metatable msg]
   `(assert (= (getmetatable ,value) ,metatable) ,msg))
 
@@ -83,4 +89,6 @@
  : assertthread?
  : assertboolean
  : assertboolean?
+ : assertnumber
+ : assertnumber?
  : assertmetatable}

--- a/lua/snap/producer/ripgrep/vimgrep.lua
+++ b/lua/snap/producer/ripgrep/vimgrep.lua
@@ -8,6 +8,10 @@ vimgrep.default = function(request)
   local cwd = snap.sync(vim.fn.getcwd)
   return general(request, {args = tbl.concat(args, {request.filter}), cwd = cwd})
 end
+vimgrep.hidden = function(request)
+  local cwd = snap.sync(vim.fn.getcwd)
+  return general(request, {args = tbl.concat(args, {"--hidden", request.filter}), cwd = cwd})
+end
 vimgrep.args = function(new_args, cwd)
   local args0 = tbl.concat(args, new_args)
   local absolute = (cwd ~= nil)

--- a/lua/snap/view/input.lua
+++ b/lua/snap/view/input.lua
@@ -51,14 +51,20 @@ local function layout(config)
   local row = _let_0_["row"]
   local width = _let_0_["width"]
   local _3_
-  if config["has-views"]() then
-    _3_ = math.floor((width * size["view-width"]))
+  if config.reverse then
+    _3_ = row
   else
-    _3_ = width
+    _3_ = ((row + height) - size.padding)
   end
-  return {col = col, focusable = true, height = 1, row = ((row + height) - size.padding), width = _3_}
+  local _5_
+  if config["has-views"]() then
+    _5_ = (math.floor((width * size["view-width"])) - size.padding - size.padding)
+  else
+    _5_ = width
+  end
+  return {col = col, focusable = true, height = 1, row = _3_, width = _5_}
 end
-local mappings = {["enter-split"] = {"<C-x>"}, ["enter-tab"] = {"<C-t>"}, ["enter-vsplit"] = {"<C-v>"}, ["next-item"] = {"<C-n>"}, ["next-page"] = {"<C-f>"}, ["prev-item"] = {"<C-p>"}, ["prev-page"] = {"<C-b>"}, ["select-all"] = {"<C-a>"}, ["view-page-down"] = {"<C-d>"}, ["view-page-up"] = {"<C-u>"}, ["view-toggle-hide"] = {"<C-h>"}, enter = {"<CR>"}, exit = {"<Esc>", "<C-c>"}, next = {"<C-q>"}, select = {"<Tab>"}, unselect = {"<S-Tab>"}}
+local mappings = {["enter-split"] = {"<C-x>"}, ["enter-tab"] = {"<C-t>"}, ["enter-vsplit"] = {"<C-v>"}, ["next-item"] = {"<C-n>", "<Down>", "<C-j>"}, ["next-page"] = {"<C-f>", "<PageDown"}, ["prev-item"] = {"<C-p>", "<Up>", "<C-k>"}, ["prev-page"] = {"<C-b>", "<PageUp>"}, ["select-all"] = {"<C-a>"}, ["view-page-down"] = {"<C-d>"}, ["view-page-up"] = {"<C-u>"}, ["view-toggle-hide"] = {"<C-h>"}, enter = {"<CR>"}, exit = {"<Esc>", "<C-c>"}, next = {"<C-q>"}, select = {"<Tab>"}, unselect = {"<S-Tab>"}}
 local create
 do
   local v_0_
@@ -140,36 +146,8 @@ do
       register["buf-map"](bufnr, {"n", "i"}, mappings0.select, on_tab)
       register["buf-map"](bufnr, {"n", "i"}, mappings0.unselect, on_shifttab)
       register["buf-map"](bufnr, {"n", "i"}, mappings0["select-all"], on_ctrla)
-      local _7_
-      if config.reverse then
-        _7_ = {"<Down>", "<C-j>"}
-      else
-        _7_ = {"<Up>", "<C-k>"}
-      end
-      register["buf-map"](bufnr, {"n", "i"}, _7_, config["on-prev-item"])
-      local _9_
-      if config.reverse then
-        _9_ = {"<Up>", "<C-k>"}
-      else
-        _9_ = {"<Down>", "<C-j>"}
-      end
-      register["buf-map"](bufnr, {"n", "i"}, _9_, config["on-next-item"])
       register["buf-map"](bufnr, {"n", "i"}, mappings0["prev-item"], config["on-prev-item"])
       register["buf-map"](bufnr, {"n", "i"}, mappings0["next-item"], config["on-next-item"])
-      local _11_
-      if config.reverse then
-        _11_ = {"<PageDown>"}
-      else
-        _11_ = {"<PageUp>"}
-      end
-      register["buf-map"](bufnr, {"n", "i"}, _11_, config["on-prev-page"])
-      local _13_
-      if config.reverse then
-        _13_ = {"<PageUp>"}
-      else
-        _13_ = {"<PageDown>"}
-      end
-      register["buf-map"](bufnr, {"n", "i"}, _13_, config["on-next-page"])
       register["buf-map"](bufnr, {"n", "i"}, mappings0["prev-page"], config["on-prev-page"])
       register["buf-map"](bufnr, {"n", "i"}, mappings0["next-page"], config["on-next-page"])
       register["buf-map"](bufnr, {"n", "i"}, mappings0["view-page-down"], config["on-viewpagedown"])
@@ -198,10 +176,10 @@ do
       local view = {bufnr = bufnr, delete = delete, height = layout_config.height, update = update, width = layout_config.width, winnr = winnr}
       vim.api.nvim_command("augroup SnapInputViewResize")
       vim.api.nvim_command("autocmd!")
-      local function _15_()
+      local function _7_()
         return view:update()
       end
-      vim.api.nvim_command(string.format("autocmd VimResized * %s", register["get-autocmd-call"]("VimResized", _15_)))
+      vim.api.nvim_command(string.format("autocmd VimResized * %s", register["get-autocmd-call"]("VimResized", _7_)))
       vim.api.nvim_command("augroup END")
       return view
     end

--- a/lua/snap/view/results.lua
+++ b/lua/snap/view/results.lua
@@ -50,12 +50,18 @@ local function layout(config)
   local row = _let_0_["row"]
   local width = _let_0_["width"]
   local _3_
-  if config["has-views"]() then
-    _3_ = math.floor((width * size["view-width"]))
+  if config.reverse then
+    _3_ = (row + size.border + size.padding + size.padding)
   else
-    _3_ = width
+    _3_ = row
   end
-  return {col = col, focusable = false, height = (height - size.border - size.border - size.padding), row = row, width = _3_}
+  local _5_
+  if config["has-views"]() then
+    _5_ = (math.floor((width * size["view-width"])) - size.padding - size.padding)
+  else
+    _5_ = width
+  end
+  return {col = col, focusable = false, height = (height - size.border - size.border - size.padding), row = _3_, width = _5_}
 end
 local create
 do
@@ -83,6 +89,7 @@ do
       local function update(view)
         local layout_config0 = layout(config)
         window.update(winnr, layout_config0)
+        vim.api.nvim_win_set_option(winnr, "cursorline", true)
         do end (view)["height"] = layout_config0.height
         view["width"] = layout_config0.width
         return nil

--- a/lua/snap/view/view.lua
+++ b/lua/snap/view/view.lua
@@ -58,7 +58,7 @@ local function layout(config)
   local sizes = tbl.allocate((height - total_borders - total_paddings), config["total-views"])
   local height0 = sizes[config.index]
   local col_offset = math.floor((width * size["view-width"]))
-  return {col = (col + col_offset + (size.border * 2) + size.padding), focusable = false, height = height0, row = (row + tbl.sum(tbl.take(sizes, index)) + border + padding), width = (width - col_offset)}
+  return {col = (col + col_offset + (size.border * 2) + size.padding), focusable = false, height = height0, row = (row + tbl.sum(tbl.take(sizes, index)) + border + padding), width = (width - col_offset - size.padding - size.padding - size.border)}
 end
 local create
 do

--- a/plugin/snap.vim
+++ b/plugin/snap.vim
@@ -9,7 +9,7 @@ endif
 
 let g:loaded_snap = 1
 
-highlight default link SnapSelect WildMenu
+highlight default link SnapSelect Visual
 highlight default link SnapMultiSelect Type
 
 highlight default link SnapNormal Normal


### PR DESCRIPTION
The following is my proposed strategy for making registering maps and commands a nicer experience in snap, as well as providing an easy way to create snap-invoking functions with default configuration and a configuration API.

See config/init.fnl for documentation.

The way that you use it with via the new `snap.map`/`snap.maps` APIs, which is a less raw version of the `snap.register.map` API (it uses `snap.register.map` under the hood.

For example here is some snap map and command registering with the new API:

```lua
local file = config.file:with {reverse = true, suffix = "»"}
local vimgrep = config.vimgrep:with {limit = 50000}
local args = {"--hidden", "--iglob", "!.git/*"}

snap.maps {
  {"<Leader><Leader>", file {producer = "ripgrep.file", args = args}, "files"},
  {"<Leader>sssss", file {producer = "ripgrep.file", prompt = "CustomPrompt"}},
  {"<Leader>fg", file {producer = "git.file"}, "git.files"},
  {"<Leader>fb", file {producer = "vim.buffer"}, "buffers"},
  {"<Leader>ff", vimgrep {}, "grep"},
  {"<Leader>fo", file {producer = "vim.oldfile"}, "oldfiles"},
  {"<Leader>fs", file {args = args, try = {"git.file", "ripgrep.file"}}, "git-with-fallback"},
  {"<Leader>aaaa", file {combine = {"vim.buffer", "vim.oldfiles"}}}
}
```

This will register the specified maps in normal mode, and will also register the functions produced by the `defaults.*` calls to be run from named commands, e.g. `:Snap git.files`, or `:Snap files`.

If possible I would like to get the thoughts/review of @ahmedelgabri @leiserfg @beauwilliams @astridlyre @scwfri @akinsho @babygau @gegoune @zetashift, if you are unable to no worries, I just don't want to land this new API without feedback.

Thanks!!

Screenshot showing the commands:

<img width="1440" alt="Screen Shot 2021-06-23 at 5 04 47 PM" src="https://user-images.githubusercontent.com/51294/123038791-298efa00-d445-11eb-9a99-9b9daf2c68f7.png">
