### PR TITLE
Implement display function to allow custom result rendering

### DIFF
--- a/fnl/snap/init.fnl
+++ b/fnl/snap/init.fnl
@@ -115,6 +115,18 @@
   (assertstring field "field passed to snap.has_meta must be a string")
   (and (= (getmetatable result) meta_tbl) (not= (. result field) nil)))
 
+(defn display [result]
+  (when (not (has_meta result :displayed))
+    (with_meta result :displayed
+      (let [display_fn
+        (if (has_meta result :display)
+            (do
+              (assertfunction result.display "display meta must be a function")
+              result.display)
+            tostring)]
+        (display_fn result))))
+  result.displayed)
+
 ;; Run docs:
 ;;
 ;; @config: {
@@ -290,7 +302,7 @@
                 partial-results []]
             (each [_ result (ipairs results)
                    :until (= max (length partial-results))]
-              (table.insert partial-results (tostring result)))
+              (table.insert partial-results (display result)))
 
             ;; Update length
             (set partial-results-length (length partial-results))

--- a/lua/snap/init.lua
+++ b/lua/snap/init.lua
@@ -298,6 +298,29 @@ do
   t_0_["has_meta"] = v_0_
   has_meta = v_0_
 end
+local display
+do
+  local v_0_
+  do
+    local v_0_0
+    local function display0(result)
+      if not has_meta(result, "displayed") then
+        local function _3_()
+          local display_fn = tostring
+          return display_fn(result)
+        end
+        with_meta(result, "displayed", _3_())
+      end
+      return result.displayed
+    end
+    v_0_0 = display0
+    _0_["display"] = v_0_0
+    v_0_ = v_0_0
+  end
+  local t_0_ = (_0_)["aniseed/locals"]
+  t_0_["display"] = v_0_
+  display = v_0_
+end
 local run
 do
   local v_0_
@@ -454,7 +477,7 @@ do
                 local partial_results = {}
                 for _, result in ipairs(results0) do
                   if (max == #partial_results) then break end
-                  table.insert(partial_results, tostring(result))
+                  table.insert(partial_results, display(result))
                 end
                 partial_results_length = #partial_results
                 if config.reverse then


### PR DESCRIPTION
Adds special handling for the `display` meta-field, which is an optional function returning a string from a `MetaResult`, and which is used to render a result for display in the selection window.

This PR is WIP. It mostly works, e.g. with the snippet:
```lua
local snap = require('snap')
local icons = require('nvim-web-devicons')
require('nvim-web-devicons').setup({default = true})

local fnamemodify = vim.fn.fnamemodify
local get_icon = icons.get_icon
local function add_icon(meta_result)
  local filename = fnamemodify(meta_result.result, ':t:r')
  local extension = fnamemodify(meta_result.result, ':e')
  local icon = get_icon(filename, extension)
  return icon .. ' ' .. meta_result.result
end

local function icons_consumer(producer)
  return function(request)
    for results in snap.consume(producer, request) do
      if type(results) == 'table' then
        if not vim.tbl_islist(results) then coroutine.yield(results) end
        coroutine.yield(vim.tbl_map(function(result)
          return snap.with_meta(result, 'display', add_icon)
        end, results))
      else
        coroutine.yield(nil)
      end
    end
  end
end

snap.register.map('n', '<Leader>s', snap.create(function()
  return {
    prompt = 'Files',
    producer = icons_consumer(snap.get('consumer.fzy')(snap.get('producer.git.file'))),
    select = snap.get('select.file').select,
    multiselect = snap.get('select.file').multiselect,
    views = {snap.get('preview.file')}
  }
end))
```

However:
- [ ] It causes the results window to be empty until a filter character is pressed, even for producers which do not add a `display` field
- [ ] It breaks the offsets for highlights showing character matches (I'm not sure the best way to handle this, since I don't know how those highlights are computed)
- [ ] The `icons_consumer` function in the above example is not quite right - sometimes the `fzy` producer yields a table `{continue = true}`, and yielding this again causes an error.
- [ ] The display caching doesn't work as expected, presumably because result objects are being created repeatedly and not reused. This is a minor point and can probably be ignored for now.

@camspiers: if you have a chance to take a look at this, I'd appreciate guidance on how the `fzy` producer works to fix the second and third items above. If you have any suggestions for why the first item may be happening, that'd be great too, but I haven't dug into that issue yet.