### PR TITLE
fix: add syntax highlighting to help preview

### DIFF
--- a/fnl/snap/preview/help.fnl
+++ b/fnl/snap/preview/help.fnl
@@ -8,4 +8,5 @@
       (when (not (request.canceled))
         (vim.api.nvim_buf_set_option request.bufnr :buftype :help)
         (vim.api.nvim_buf_call request.bufnr (fn []
-          (vim.api.nvim_command (string.format "noautocmd help %s" (tostring request.selection))))))))))
+          (vim.api.nvim_command (string.format "noautocmd help %s" (tostring request.selection)))
+          (vim.api.nvim_buf_set_option request.bufnr :syntax :help))))))))

--- a/lua/snap/preview/help.lua
+++ b/lua/snap/preview/help.lua
@@ -8,7 +8,8 @@ local function _1_(request)
     if not request.canceled() then
       vim.api.nvim_buf_set_option(request.bufnr, "buftype", "help")
       local function _3_()
-        return vim.api.nvim_command(string.format("noautocmd help %s", tostring(request.selection)))
+        vim.api.nvim_command(string.format("noautocmd help %s", tostring(request.selection)))
+        return vim.api.nvim_buf_set_option(request.bufnr, "syntax", "help")
       end
       return vim.api.nvim_buf_call(request.bufnr, _3_)
     end


### PR DESCRIPTION
This PR fixes the issue I mentioned in #22 regarding the missing syntax highlighting for help files.