### PR TITLE
Adding changes to show untracked files with git file search

### DIFF
--- a/fnl/snap/producer/git/file.fnl
+++ b/fnl/snap/producer/git/file.fnl
@@ -3,6 +3,6 @@
   (fn [request]
     (let [cwd (snap.sync vim.fn.getcwd)]
         (if (not= (general request {:args [:ls-files :-o] : cwd}) nil)
-            (.. (general request {:args [:ls-files] : cwd}) (general request {:args [:ls-files :-o] : cwd}))))
-                (general request {:args [:ls-files] : cwd})))
+            (.. (general request {:args [:ls-files] : cwd}) (general request {:args [:ls-files :-o] : cwd})))
+                (general request {:args [:ls-files] : cwd}))))
 

--- a/fnl/snap/producer/git/file.fnl
+++ b/fnl/snap/producer/git/file.fnl
@@ -2,4 +2,7 @@
       general (snap.get :producer.git.general)]
   (fn [request]
     (let [cwd (snap.sync vim.fn.getcwd)]
-        (.. (general request {:args [:ls-files] : cwd}) (general request {:args [:ls-files :-o] : cwd})))))
+        (if (not= (general request {:args [:ls-files :-o] : cwd}) nil)
+            (.. (general request {:args [:ls-files] : cwd}) (general request {:args [:ls-files :-o] : cwd}))))
+                (general request {:args [:ls-files] : cwd})))
+

--- a/fnl/snap/producer/git/file.fnl
+++ b/fnl/snap/producer/git/file.fnl
@@ -2,4 +2,4 @@
       general (snap.get :producer.git.general)]
   (fn [request]
     (let [cwd (snap.sync vim.fn.getcwd)]
-      (general request {:args [:ls-files] : cwd}))))
+        (.. (general request {:args [:ls-files] : cwd}) (general request {:args [:ls-files :-o] : cwd})))))

--- a/fnl/snap/producer/git/file.fnl
+++ b/fnl/snap/producer/git/file.fnl
@@ -3,6 +3,6 @@
   (fn [request]
     (let [cwd (snap.sync vim.fn.getcwd)]
         (if (not= (general request {:args [:ls-files :-o] : cwd}) nil)
-            (.. (general request {:args [:ls-files] : cwd}) (general request {:args [:ls-files :-o] : cwd})))
-                (general request {:args [:ls-files] : cwd}))))
+            (.. (general request {:args [:ls-files] : cwd}) (general request {:args [:ls-files :-o] : cwd}))
+                (general request {:args [:ls-files] : cwd})))))
 

--- a/lua/snap/producer/git/file.lua
+++ b/lua/snap/producer/git/file.lua
@@ -3,6 +3,6 @@ local snap = require("snap")
 local general = snap.get("producer.git.general")
 local function _1_(request)
   local cwd = snap.sync(vim.fn.getcwd)
-  return general(request, {args = {"ls-files"}, cwd = cwd})
+  return (general(request, {args = {"ls-files"}, cwd = cwd}) .. general(request, {args = {"ls-files", "-o"}, cwd = cwd}))
 end
 return _1_

--- a/lua/snap/producer/git/file.lua
+++ b/lua/snap/producer/git/file.lua
@@ -2,7 +2,12 @@ local _2afile_2a = "fnl/snap/producer/git/file.fnl"
 local snap = require("snap")
 local general = snap.get("producer.git.general")
 local function _1_(request)
-  local cwd = snap.sync(vim.fn.getcwd)
-  return (general(request, {args = {"ls-files"}, cwd = cwd}) .. general(request, {args = {"ls-files", "-o"}, cwd = cwd}))
+  do
+    local cwd = snap.sync(vim.fn.getcwd)
+    if (general(request, {args = {"ls-files", "-o"}, cwd = cwd}) ~= nil) then
+      do local _ = (general(request, {args = {"ls-files"}, cwd = cwd}) .. general(request, {args = {"ls-files", "-o"}, cwd = cwd})) end
+    end
+  end
+  return general(request, {args = {"ls-files"}, cwd = cwd})
 end
 return _1_

--- a/lua/snap/producer/git/file.lua
+++ b/lua/snap/producer/git/file.lua
@@ -4,8 +4,9 @@ local general = snap.get("producer.git.general")
 local function _1_(request)
   local cwd = snap.sync(vim.fn.getcwd)
   if (general(request, {args = {"ls-files", "-o"}, cwd = cwd}) ~= nil) then
-    do local _ = (general(request, {args = {"ls-files"}, cwd = cwd}) .. general(request, {args = {"ls-files", "-o"}, cwd = cwd})) end
+    return (general(request, {args = {"ls-files"}, cwd = cwd}) .. general(request, {args = {"ls-files", "-o"}, cwd = cwd}))
+  else
+    return general(request, {args = {"ls-files"}, cwd = cwd})
   end
-  return general(request, {args = {"ls-files"}, cwd = cwd})
 end
 return _1_

--- a/lua/snap/producer/git/file.lua
+++ b/lua/snap/producer/git/file.lua
@@ -2,11 +2,9 @@ local _2afile_2a = "fnl/snap/producer/git/file.fnl"
 local snap = require("snap")
 local general = snap.get("producer.git.general")
 local function _1_(request)
-  do
-    local cwd = snap.sync(vim.fn.getcwd)
-    if (general(request, {args = {"ls-files", "-o"}, cwd = cwd}) ~= nil) then
-      do local _ = (general(request, {args = {"ls-files"}, cwd = cwd}) .. general(request, {args = {"ls-files", "-o"}, cwd = cwd})) end
-    end
+  local cwd = snap.sync(vim.fn.getcwd)
+  if (general(request, {args = {"ls-files", "-o"}, cwd = cwd}) ~= nil) then
+    do local _ = (general(request, {args = {"ls-files"}, cwd = cwd}) .. general(request, {args = {"ls-files", "-o"}, cwd = cwd})) end
   end
   return general(request, {args = {"ls-files"}, cwd = cwd})
 end


### PR DESCRIPTION
This PR adds untracked files to the git.files producer output, to mimic the behaviour of many other git files finders which by default make untracked files searchable e.g telescope.nvim