### PR TITLE
Minor fixes for #42

### DIFF
--- a/fnl/snap/config/init.fnl
+++ b/fnl/snap/config/init.fnl
@@ -121,6 +121,7 @@
   - prompt
   - suffix
   - reverse
+  - mappings
   - preview_min_width
   - preview
 
@@ -168,7 +169,7 @@
   (asserttable?    config.try               "file.try must be a table")
   (asserttable?    config.combine           "file.combine must be a table")
   (assertboolean?  config.reverse           "file.reverse must be a boolean")
-  (assertnumber?   config.preview_min_width "file.preview-min-with must be a boolean")
+  (assertnumber?   config.preview_min_width "file.preview-min-with must be a number")
   (asserttable?    config.mappings          "file.mappings must be a table")
   (asserttypes?    [:function :boolean] config.preview "file.preview must be a boolean or a function")
 
@@ -345,6 +346,7 @@
           views [(snap.get :preview.vimgrep)]]
       (snap.run {: prompt
                  : layout
+                 : reverse
                  : mappings
                  : producer
                  : select

--- a/lua/snap/config/init.lua
+++ b/lua/snap/config/init.lua
@@ -186,7 +186,7 @@ do
           assert((type(config.reverse) == "boolean"), "file.reverse must be a boolean")
         end
         if config.preview_min_width then
-          assert((type(config.preview_min_width) == "number"), "file.preview-min-with must be a boolean")
+          assert((type(config.preview_min_width) == "number"), "file.preview-min-with must be a number")
         end
         if config.mappings then
           assert((type(config.mappings) == "table"), "file.mappings must be a table")
@@ -393,7 +393,7 @@ do
           local multiselect = vimgrep_select.multiselect
           local initial_filter = get_initial_filter(config)
           local views = {snap.get("preview.vimgrep")}
-          return snap.run({hide_views = hide_views0, initial_filter = initial_filter, layout = layout, mappings = mappings, multiselect = multiselect, producer = producer0, prompt = prompt, select = select, views = views})
+          return snap.run({hide_views = hide_views0, initial_filter = initial_filter, layout = layout, mappings = mappings, multiselect = multiselect, producer = producer0, prompt = prompt, reverse = reverse, select = select, views = views})
         end
         return _19_
       end


### PR DESCRIPTION
- Adding `mappings` to Additional options list
- Fix assertion for `preview_min_width`
- Pass `reverse` to `vimgrep`

I also noticed that the assertion for `preview` is different between `file` (`boolean` or `function`) & `vimgrep` (only a `boolean`) so not sure if this is intentional or not.