### PR TITLE
docs: update command usage in config api example

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ If you want to also make your function available via the `:Snap myexamplefunctio
 ```lua
 local snap = require'snap'
 snap.maps {
-  {"<Leader><Leader>", snap.config.file {producer = "ripgrep.file"}, "mycommandname"}
+  {"<Leader><Leader>", snap.config.file {producer = "ripgrep.file"}, {command = "mycommandname"}}
 }
 ```
 


### PR DESCRIPTION
Just a README update as the string argument has been deprecated and this might confuse users otherwise.