### PR TITLE
Add ripgrep producer alternative for line-based grep

### DIFF
--- a/fnl/snap/producer/ripgrep/vimgrep.fnl
+++ b/fnl/snap/producer/ripgrep/vimgrep.fnl
@@ -3,12 +3,19 @@
       general (snap.get :producer.ripgrep.general)]
   (local vimgrep {})
   (local args [:--line-buffered :-M 100 :--vimgrep])
+  (local line-args [:--line-buffered :-M 100 :--no-heading :--column])
   (fn vimgrep.default [request]
     (let [cwd (snap.sync vim.fn.getcwd)]
       (general request {:args (tbl.concat args [request.filter]) : cwd})))
   (fn vimgrep.hidden [request]
     (let [cwd (snap.sync vim.fn.getcwd)]
       (general request {:args (tbl.concat args [:--hidden request.filter]) : cwd})))
+  (fn vimgrep.line [new-args cwd]
+    (let [args (tbl.concat line-args new-args)
+          absolute (not= cwd nil)]
+      (fn [request]
+        (let [cmd (or cwd (snap.sync vim.fn.getcwd))]
+          (general request {:args (tbl.concat args [request.filter]) : cwd : absolute})))))
   (fn vimgrep.args [new-args cwd]
     (let [args (tbl.concat args new-args)
           absolute (not= cwd nil)]

--- a/lua/snap/producer/ripgrep/vimgrep.lua
+++ b/lua/snap/producer/ripgrep/vimgrep.lua
@@ -3,6 +3,7 @@ local snap = require("snap")
 local tbl = snap.get("common.tbl")
 local general = snap.get("producer.ripgrep.general")
 local vimgrep = {}
+local line_args = {"--line-buffered", "-M", 100, "--no-heading", "--column"}
 local args = {"--line-buffered", "-M", 100, "--vimgrep"}
 vimgrep.default = function(request)
   local cwd = snap.sync(vim.fn.getcwd)
@@ -11,6 +12,15 @@ end
 vimgrep.hidden = function(request)
   local cwd = snap.sync(vim.fn.getcwd)
   return general(request, {args = tbl.concat(args, {"--hidden", request.filter}), cwd = cwd})
+end
+vimgrep.line = function(new_args, cwd)
+  local args0 = tbl.concat(line_args, new_args)
+  local absolute = (cwd ~= nil)
+  local function _1_(request)
+    local cmd = (cwd or snap.sync(vim.fn.getcwd))
+    return general(request, {absolute = absolute, args = tbl.concat(args0, {request.filter}), cwd = cwd})
+  end
+  return _1_
 end
 vimgrep.args = function(new_args, cwd)
   local args0 = tbl.concat(args, new_args)


### PR DESCRIPTION
A grep with `--vimgrep` will produce duplicate lines as there are multiple matches within the same line. While the introduced `ripgrep.vimgrep.line` producer will produce only a single line per match, regardless of multiple matches within the same line. This should help in a case where only line matches are needed, and to not waste processing power to the filtering.

![IMG_8422](https://user-images.githubusercontent.com/1087399/124365491-a191c700-dc72-11eb-8887-7b4144a0fecf.jpeg)
