### PR TITLE
add delimeter to separate flags from search pattern

### DIFF
--- a/fnl/snap/producer/ripgrep/vimgrep.fnl
+++ b/fnl/snap/producer/ripgrep/vimgrep.fnl
@@ -6,20 +6,20 @@
   (local line-args [:--line-buffered :-M 100 :--no-heading :--column])
   (fn vimgrep.default [request]
     (let [cwd (snap.sync vim.fn.getcwd)]
-      (general request {:args (tbl.concat args [request.filter]) : cwd})))
+      (general request {:args (tbl.concat args [:-- request.filter]) : cwd})))
   (fn vimgrep.hidden [request]
     (let [cwd (snap.sync vim.fn.getcwd)]
-      (general request {:args (tbl.concat args [:--hidden request.filter]) : cwd})))
+      (general request {:args (tbl.concat args [:--hidden :-- request.filter]) : cwd})))
   (fn vimgrep.line [new-args cwd]
     (let [args (tbl.concat line-args new-args)
           absolute (not= cwd nil)]
       (fn [request]
         (let [cmd (or cwd (snap.sync vim.fn.getcwd))]
-          (general request {:args (tbl.concat args [request.filter]) : cwd : absolute})))))
+          (general request {:args (tbl.concat args [:-- request.filter]) : cwd : absolute})))))
   (fn vimgrep.args [new-args cwd]
     (let [args (tbl.concat args new-args)
           absolute (not= cwd nil)]
       (fn [request]
         (let [cwd (or cwd (snap.sync vim.fn.getcwd))]
-          (general request {:args (tbl.concat args [request.filter]) : cwd : absolute})))))
+          (general request {:args (tbl.concat args [:-- request.filter]) : cwd : absolute})))))
   vimgrep)

--- a/lua/snap/producer/ripgrep/vimgrep.lua
+++ b/lua/snap/producer/ripgrep/vimgrep.lua
@@ -3,22 +3,22 @@ local snap = require("snap")
 local tbl = snap.get("common.tbl")
 local general = snap.get("producer.ripgrep.general")
 local vimgrep = {}
-local line_args = {"--line-buffered", "-M", 100, "--no-heading", "--column"}
 local args = {"--line-buffered", "-M", 100, "--vimgrep"}
+local line_args = {"--line-buffered", "-M", 100, "--no-heading", "--column"}
 vimgrep.default = function(request)
   local cwd = snap.sync(vim.fn.getcwd)
-  return general(request, {args = tbl.concat(args, {request.filter}), cwd = cwd})
+  return general(request, {args = tbl.concat(args, {"--", request.filter}), cwd = cwd})
 end
 vimgrep.hidden = function(request)
   local cwd = snap.sync(vim.fn.getcwd)
-  return general(request, {args = tbl.concat(args, {"--hidden", request.filter}), cwd = cwd})
+  return general(request, {args = tbl.concat(args, {"--hidden", "--", request.filter}), cwd = cwd})
 end
 vimgrep.line = function(new_args, cwd)
   local args0 = tbl.concat(line_args, new_args)
   local absolute = (cwd ~= nil)
   local function _1_(request)
     local cmd = (cwd or snap.sync(vim.fn.getcwd))
-    return general(request, {absolute = absolute, args = tbl.concat(args0, {request.filter}), cwd = cwd})
+    return general(request, {absolute = absolute, args = tbl.concat(args0, {"--", request.filter}), cwd = cwd})
   end
   return _1_
 end
@@ -27,7 +27,7 @@ vimgrep.args = function(new_args, cwd)
   local absolute = (cwd ~= nil)
   local function _1_(request)
     local cwd0 = (cwd or snap.sync(vim.fn.getcwd))
-    return general(request, {absolute = absolute, args = tbl.concat(args0, {request.filter}), cwd = cwd0})
+    return general(request, {absolute = absolute, args = tbl.concat(args0, {"--", request.filter}), cwd = cwd0})
   end
   return _1_
 end


### PR DESCRIPTION
From rg man page:
> You can also use the special -- delimiter to indicate that no more flags
>            will be provided.

This will fix search with a '--' character

Example file:
$ cat test 
XXX --type=lua

