### PR TITLE
Fix encoding check for paths with special chars

### DIFF
--- a/fnl/snap/preview/common/read-file.fnl
+++ b/fnl/snap/preview/common/read-file.fnl
@@ -1,7 +1,7 @@
 (let [snap (require :snap)
       snap-io (snap.get :common.io)]
   (fn get-encoding [path]
-    (local handle (io.popen (string.format "file -n -b --mime-encoding %s" path)))
+    (local handle (io.popen (string.format "file -n -b --mime-encoding '%s'" path)))
     (local encoding (string.gsub (handle:read "*a") "^%s*(.-)%s*$" "%1") )
     (handle:close)
     encoding)

--- a/lua/snap/preview/common/read-file.lua
+++ b/lua/snap/preview/common/read-file.lua
@@ -2,7 +2,7 @@ local _2afile_2a = "fnl/snap/preview/common/read-file.fnl"
 local snap = require("snap")
 local snap_io = snap.get("common.io")
 local function get_encoding(path)
-  local handle = io.popen(string.format("file -n -b --mime-encoding %s", path))
+  local handle = io.popen(string.format("file -n -b --mime-encoding '%s'", path))
   local encoding = string.gsub(handle:read("*a"), "^%s*(.-)%s*$", "%1")
   handle:close()
   return encoding


### PR DESCRIPTION
Hi there!

I recently started using `snap` in my nvim config and I'm a big fan, thank you for this tool!

However, I noticed a bug: when fuzzy finding files that contains special characters (in my case `(` in a Next.js project), an error message is displayed randomly in the window:

![Screenshot 2024-06-22 at 03 43 59 PM@2x](https://github.com/camspiers/snap/assets/980367/c61a7e0a-d65a-4a8b-96cf-ca59916f5bc4)

This PR adds quotes around the path template so that the command can run without issues. If needed, I created this [this repo](https://github.com/aliou/snap-special-chars-repro) to reproduce the issue.

I also included the generated Lua file in the PR, let me know if it should be removed.

Thanks!